### PR TITLE
support both file and CLASSPATH-based config loading - #9

### DIFF
--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerFactory.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerFactory.java
@@ -128,7 +128,7 @@ public class ChronicleLoggerFactory implements ILoggerFactory {
     /**
      *
      */
-    public synchronized void relaod() {
+    public synchronized void reload() {
         shutdown();
 
         this.cfg = ChronicleLoggingConfig.load();

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggingConfigTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggingConfigTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 Higher Frequency Trading
+ *
+ * http://www.higherfrequencytrading.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.logger.slf4j;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class ChronicleLoggingConfigTest {
+    @Test
+    public void testLoadNoProperty() throws Exception {
+        assertNull("config should not load if no system property set up", ChronicleLoggingConfig.load());
+    }
+
+    @Test
+    public void testLoadFileVanilla() throws Exception {
+        System.setProperty("slf4j.chronicle.properties", System.getProperty("slf4j.chronicle.vanilla.properties"));
+        assertLoadsValidVanillaConfig();
+    }
+
+    @Test
+    public void testLoadClasspathVanilla() throws Exception {
+        System.setProperty("slf4j.chronicle.properties", "slf4j.chronicle.vanilla.properties");
+        assertLoadsValidVanillaConfig();
+    }
+
+    private void assertLoadsValidVanillaConfig() {
+        ChronicleLoggingConfig config = ChronicleLoggingConfig.load();
+        assertNotNull("unable to load config", config);
+        assertNotNull("is not a vanilla config", config.getVanillaChronicleConfig());
+        assertEquals(ChronicleLoggingConfig.FORMAT_BINARY, config.getString(ChronicleLoggingConfig.KEY_FORMAT));
+    }
+}

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleBinaryLoggerPerfTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleBinaryLoggerPerfTest.java
@@ -46,7 +46,7 @@ public class Slf4jIndexedChronicleBinaryLoggerPerfTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.indexed.binary.perf.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleBinaryLoggerTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleBinaryLoggerTest.java
@@ -52,7 +52,7 @@ public class Slf4jIndexedChronicleBinaryLoggerTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.indexed.binary.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleLoggerPerfTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleLoggerPerfTest.java
@@ -46,7 +46,7 @@ public class Slf4jIndexedChronicleLoggerPerfTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.indexed.perf.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleLoggerTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jIndexedChronicleLoggerTest.java
@@ -53,7 +53,7 @@ public class Slf4jIndexedChronicleLoggerTest extends Slf4jTestBase {
             System.getProperty("slf4j.chronicle.indexed.properties")
         );
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleBinaryLoggerPerfTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleBinaryLoggerPerfTest.java
@@ -46,7 +46,7 @@ public class Slf4jVanillaChronicleBinaryLoggerPerfTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.vanilla.perf.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleBinaryLoggerTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleBinaryLoggerTest.java
@@ -52,7 +52,7 @@ public class Slf4jVanillaChronicleBinaryLoggerTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.vanilla.binary.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleLoggerPerfTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleLoggerPerfTest.java
@@ -46,7 +46,7 @@ public class Slf4jVanillaChronicleLoggerPerfTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.vanilla.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleLoggerTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jVanillaChronicleLoggerTest.java
@@ -52,7 +52,7 @@ public class Slf4jVanillaChronicleLoggerTest extends Slf4jTestBase {
             "slf4j.chronicle.properties",
             System.getProperty("slf4j.chronicle.vanilla.properties"));
 
-        getChronicleLoggerFactory().relaod();
+        getChronicleLoggerFactory().reload();
     }
 
     @After


### PR DESCRIPTION
This includes change to support both CLASSPATH and File loading, for #9, and also a very minor change: the reload() method was mis-spelled. Added unit test for both File & CLASSPATH loading.
