### PR TITLE
Maven bundle plugin configuration changed to include resources generated...

### DIFF
--- a/logger-log4j-2/pom.xml
+++ b/logger-log4j-2/pom.xml
@@ -90,6 +90,7 @@
                         </Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Export-Package>net.openhft.chronicle.logger.log4j2.*</Export-Package>
+                        <Include-Resource>META-INF=target/classes/META-INF</Include-Resource>
                     </instructions>
                 </configuration>
                 <executions>


### PR DESCRIPTION
... by log4j annotation processor (by default it will not include those like jar plugin does)
