### PR TITLE
Code quality fix - Serializable classes should have a version id

### DIFF
--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractBinaryChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractBinaryChronicleAppender.java
@@ -25,6 +25,8 @@ import org.apache.logging.log4j.core.LogEvent;
 
 abstract class AbstractBinaryChronicleAppender extends AbstractChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private boolean includeCallerData;
     private boolean includeMDC;
 

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
@@ -34,6 +34,9 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import java.io.IOException;
 
 public abstract class AbstractChronicleAppender extends AbstractAppender {
+    
+    private static final long serialVersionUID = 1L;
+    
     private String path;
 
     protected ChronicleLogWriter writer;

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractTextChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractTextChronicleAppender.java
@@ -26,6 +26,8 @@ import org.apache.logging.log4j.core.LogEvent;
 
 abstract class AbstractTextChronicleAppender extends AbstractChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private String dateFormat;
     private int stackTraceDepth;
 

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/BinaryIndexedChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/BinaryIndexedChronicleAppender.java
@@ -36,6 +36,8 @@ import java.io.IOException;
     printObject = true)
 public class BinaryIndexedChronicleAppender extends AbstractBinaryChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private final IndexedLogAppenderConfig config;
 
     public BinaryIndexedChronicleAppender(

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/BinaryVanillaChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/BinaryVanillaChronicleAppender.java
@@ -36,6 +36,8 @@ import java.io.IOException;
     printObject = true)
 public class BinaryVanillaChronicleAppender extends AbstractBinaryChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private final VanillaLogAppenderConfig config;
 
     public BinaryVanillaChronicleAppender(

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/TextIndexedChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/TextIndexedChronicleAppender.java
@@ -36,6 +36,8 @@ import java.io.IOException;
     printObject = true)
 public class TextIndexedChronicleAppender extends AbstractTextChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private final IndexedLogAppenderConfig config;
 
     public TextIndexedChronicleAppender(

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/TextVanillaChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/TextVanillaChronicleAppender.java
@@ -36,6 +36,8 @@ import java.io.IOException;
     printObject = true)
 public class TextVanillaChronicleAppender extends AbstractTextChronicleAppender {
 
+    private static final long serialVersionUID = 1L;
+    
     private final VanillaLogAppenderConfig config;
 
     public TextVanillaChronicleAppender(

--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLogger.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLogger.java
@@ -26,6 +26,8 @@ import org.slf4j.helpers.MessageFormatter;
 
 abstract class ChronicleLogger extends MarkerIgnoringBase {
 
+    private static final long serialVersionUID = 1L;
+    
     protected final ChronicleLogWriter writer;
     protected final ChronicleLogLevel level;
 
@@ -305,6 +307,9 @@ abstract class ChronicleLogger extends MarkerIgnoringBase {
     // *************************************************************************
 
     public static final class Binary extends ChronicleLogger {
+        
+        private static final long serialVersionUID = 1L;
+        
         public Binary(ChronicleLogWriter writer, String name, ChronicleLogLevel level) {
             super(writer, name, level);
         }
@@ -384,6 +389,9 @@ abstract class ChronicleLogger extends MarkerIgnoringBase {
     // *************************************************************************
 
     public static final class Text extends ChronicleLogger {
+        
+        private static final long serialVersionUID = 1L;
+        
         public Text(ChronicleLogWriter writer, String name, ChronicleLogLevel level) {
             super(writer, name, level);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S2057 Serializable classes should have a version id

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S2057

Please let me know if you have any questions.

Faisal