### PR TITLE
Code quality fix - @Override annotation should be used on any method overriding

### DIFF
--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
@@ -141,6 +141,7 @@ public abstract class AbstractChronicleAppender implements Appender, OptionHandl
         this.name = name;
     }
 
+    @Override
     public void doAppend(LoggingEvent event) {
         if(this.writer != null) {
             for(Filter f = this.filter; f != null;f = f.getNext()) {

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
@@ -98,6 +98,7 @@ public abstract class AbstractChronicleAppender extends AbstractAppender {
         super.stop();
     }
 
+    @Override
     public void append(final LogEvent event) {
         if (this.writer != null) {
             doAppend(event, writer);

--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
@@ -90,18 +90,22 @@ public abstract class AbstractChronicleAppender
         return started;
     }
 
+    @Override
     public void addFilter(Filter<ILoggingEvent> newFilter) {
         this.filterAttachable.addFilter(newFilter);
     }
 
+    @Override
     public void clearAllFilters() {
         this.filterAttachable.clearAllFilters();
     }
 
+    @Override
     public List<Filter<ILoggingEvent>> getCopyOfAttachedFiltersList() {
         return this.filterAttachable.getCopyOfAttachedFiltersList();
     }
 
+    @Override
     public FilterReply getFilterChainDecision(ILoggingEvent event) {
         return this.filterAttachable.getFilterChainDecision(event);
     }

--- a/logger-slf4j/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -56,10 +56,12 @@ public class StaticLoggerBinder implements LoggerFactoryBinder {
         return SINGLETON;
     }
 
+    @Override
     public ILoggerFactory getLoggerFactory() {
         return loggerFactory;
     }
 
+    @Override
     public String getLoggerFactoryClassStr() {
         return loggerFactoryClassStr;
     }

--- a/logger-slf4j/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
@@ -43,6 +43,7 @@ public class StaticMarkerBinder implements MarkerFactoryBinder {
      * Currently this method always returns an instance of
      * {@link BasicMarkerFactory}.
      */
+    @Override
     public IMarkerFactory getMarkerFactory() {
         return markerFactory;
     }
@@ -51,6 +52,7 @@ public class StaticMarkerBinder implements MarkerFactoryBinder {
      * Currently, this method returns the class name of
      * {@link BasicMarkerFactory}.
      */
+    @Override
     public String getMarkerFactoryClassStr() {
         return BasicMarkerFactory.class.getName();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1161 @Override annotation should be used on any method overriding

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal