### PR TITLE
Code quality fix - Constructors should only call non-overridable methods.

### DIFF
--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/AbstractChronicleHandler.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/AbstractChronicleHandler.java
@@ -20,7 +20,9 @@ package net.openhft.chronicle.logger.jul;
 import net.openhft.chronicle.logger.ChronicleLogWriter;
 
 import java.io.IOException;
+import java.util.logging.Filter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 abstract class AbstractChronicleHandler extends Handler {
@@ -61,7 +63,17 @@ abstract class AbstractChronicleHandler extends Handler {
 
     protected abstract void doPublish(final LogRecord record, final ChronicleLogWriter writer);
 
-    protected void setWriter(ChronicleLogWriter appender) {
+    protected final void setWriter(ChronicleLogWriter appender) {
         this.writer = appender;
+    }
+    
+    @Override
+    public final void setFilter(Filter newFilter) {
+        super.setFilter(newFilter);
+    }
+
+    @Override
+    public final synchronized void setLevel(Level newLevel) {
+        super.setLevel(newLevel);
     }
 }

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
@@ -44,7 +44,14 @@ abstract class ChronicleLogger extends Logger {
         this.writer = writer;
         this.name = name;
         this.level = level;
-
+        
+        /*
+         * Set level of super class using final method
+         */
+        setLevel(level);
+    }
+    
+    private final void setLevel(final ChronicleLogLevel level) {
         super.setLevel(ChronicleHelper.getLogLevel(level));
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1699 - Constructors should only call non-overridable methods.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Faisal