### PR TITLE
Code quality fix - Printf-style format strings should not lead to unexpected behavior at runtime.

### DIFF
--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
@@ -64,10 +64,10 @@ public final class ChroniCat {
                 );
 
             } else {
-                System.err.format("\nUsage: ChroniCat [-t|-i|-u] path");
-                System.err.format("\n  -t = text chronicle, default binary");
-                System.err.format("\n  -u = use uncompressed object serialization, default compressed");
-                System.err.format("\n  -i = IndexedChronicle, default VanillaChronicle");
+                System.err.format("%nUsage: ChroniCat [-t|-i|-u] path");
+                System.err.format("%n  -t = text chronicle, default binary");
+                System.err.format("%n  -u = use uncompressed object serialization, default compressed");
+                System.err.format("%n  -i = IndexedChronicle, default VanillaChronicle");
             }
         } catch (Exception e) {
             e.printStackTrace(System.err);

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniDump.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniDump.java
@@ -107,9 +107,9 @@ public final class ChroniDump {
                 );
 
             } else {
-                System.err.format("\nUsage: ChroniDump [-i|-u] path");
-                System.err.format("\n  -u = use uncompressed object serialization, default compressed");
-                System.err.format("\n  -i = IndexedChronicle, default VanillaChronicle");
+                System.err.format("%nUsage: ChroniDump [-i|-u] path");
+                System.err.format("%n  -u = use uncompressed object serialization, default compressed");
+                System.err.format("%n  -i = IndexedChronicle, default VanillaChronicle");
             }
         } catch (Exception e) {
             e.printStackTrace(System.err);

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniGrep.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniGrep.java
@@ -75,10 +75,10 @@ public final class ChroniGrep {
                 );
 
             } else {
-                System.err.format("\nUsage: ChroniGrep [-t|-i|-u] regexp1 ... regexpN path");
-                System.err.format("\n  -u = use uncompressed object serialization, default compressed");
-                System.err.format("\n  -t = text chronicle, default binary");
-                System.err.format("\n  -i = IndexedChronicle, default VanillaChronicle");
+                System.err.format("%nUsage: ChroniGrep [-t|-i|-u] regexp1 ... regexpN path");
+                System.err.format("%n  -u = use uncompressed object serialization, default compressed");
+                System.err.format("%n  -t = text chronicle, default binary");
+                System.err.format("%n  -i = IndexedChronicle, default VanillaChronicle");
             }
         } catch (Exception e) {
             e.printStackTrace(System.err);

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTail.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTail.java
@@ -64,10 +64,10 @@ public final class ChroniTail {
                 );
 
             } else {
-                System.err.format("\nUsage: ChroniTail [-t|-i|-u] path");
-                System.err.format("\n  -t = text chronicle, default binary");
-                System.err.format("\n  -u = use uncompressed object serialization, default compressed");
-                System.err.format("\n  -i = IndexedChronicle, default VanillaChronicle");
+                System.err.format("%nUsage: ChroniTail [-t|-i|-u] path");
+                System.err.format("%n  -t = text chronicle, default binary");
+                System.err.format("%n  -u = use uncompressed object serialization, default compressed");
+                System.err.format("%n  -i = IndexedChronicle, default VanillaChronicle");
             }
         } catch (Exception e) {
             e.printStackTrace(System.err);

--- a/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriters.java
+++ b/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriters.java
@@ -406,7 +406,7 @@ public class ChronicleLogWriters {
             final String message,
             final Throwable throwable) {
             if (throwable == null) {
-                stream.printf("%s|%s|%s|%s|%s\n",
+                stream.printf("%s|%s|%s|%s|%s%n",
                     timeStampFormatter.format(timestamp),
                     level.toString(),
                     threadName,
@@ -414,7 +414,7 @@ public class ChronicleLogWriters {
                     message);
 
             } else {
-                stream.printf("%s|%s|%s|%s|%s|%s\n",
+                stream.printf("%s|%s|%s|%s|%s|%s%n",
                     timeStampFormatter.format(timestamp),
                     level.toString(),
                     threadName,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S2275

Please let me know if you have any questions.

Faisal