### PR TITLE
Code quality fix - Modifiers should be declared in the correct order.

### DIFF
--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractBinaryChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractBinaryChronicleAppender.java
@@ -60,7 +60,7 @@ abstract class AbstractBinaryChronicleAppender extends AbstractChronicleAppender
     // *************************************************************************
 
     @Override
-    public void doAppend(final @NotNull LogEvent event, final @NotNull ChronicleLogWriter writer) {
+    public void doAppend(@NotNull final LogEvent event, @NotNull final ChronicleLogWriter writer) {
         writer.write(
             toChronicleLogLevel(event.getLevel()),
             event.getTimeMillis(),

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
@@ -62,7 +62,7 @@ public abstract class AbstractChronicleAppender extends AbstractAppender {
     // *************************************************************************
 
     protected abstract ChronicleLogWriter createWriter() throws IOException;
-    protected abstract void doAppend(final @NotNull LogEvent event, final @NotNull ChronicleLogWriter writer);
+    protected abstract void doAppend(@NotNull final LogEvent event, @NotNull final ChronicleLogWriter writer);
 
     // *************************************************************************
     //

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractTextChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractTextChronicleAppender.java
@@ -61,7 +61,7 @@ abstract class AbstractTextChronicleAppender extends AbstractChronicleAppender {
     // *************************************************************************
 
     @Override
-    public void doAppend(final @NotNull LogEvent event, final @NotNull ChronicleLogWriter writer) {
+    public void doAppend(@NotNull final LogEvent event, @NotNull final ChronicleLogWriter writer) {
         writer.write(
             toChronicleLogLevel(event.getLevel()),
             event.getTimeMillis(),

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniDump.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniDump.java
@@ -27,7 +27,7 @@ import net.openhft.lang.io.Bytes;
  */
 public final class ChroniDump {
 
-    private final static char[] HEX_DIGITS = {
+    private static final char[] HEX_DIGITS = {
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
             'A', 'B', 'C', 'D', 'E', 'F'
     };

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTool.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTool.java
@@ -39,14 +39,14 @@ public final class ChroniTool {
     //
     // *************************************************************************
 
-    public static abstract class BinaryProcessor implements ChronicleLogReader, ChronicleLogProcessor {
+    public abstract static class BinaryProcessor implements ChronicleLogReader, ChronicleLogProcessor {
         @Override
         public void read(final Bytes bytes) {
             process(ChronicleLogHelper.decodeBinary(bytes));
         }
     }
 
-    public static abstract class TextProcessor implements ChronicleLogReader, ChronicleLogProcessor {
+    public abstract static class TextProcessor implements ChronicleLogReader, ChronicleLogProcessor {
         @Override
         public void read(final Bytes bytes) {
             process(ChronicleLogHelper.decodeText(bytes));

--- a/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogAppenderConfig.java
+++ b/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogAppenderConfig.java
@@ -35,7 +35,7 @@ public abstract class ChronicleLogAppenderConfig {
     public abstract Chronicle build(String path)
         throws IOException;
 
-    public void setProperties(final @NotNull Properties properties, final @Nullable String prefix) {
+    public void setProperties(@NotNull final Properties properties, @Nullable final String prefix) {
         for (final Map.Entry<Object, Object> entry : properties.entrySet()) {
             final String name = entry.getKey().toString();
             final String value = entry.getValue().toString();
@@ -50,7 +50,7 @@ public abstract class ChronicleLogAppenderConfig {
         }
     }
 
-    public void setProperty(final @NotNull String propName, final @NotNull String propValue) {
+    public void setProperty(@NotNull final String propName, @NotNull final String propValue) {
         try {
             final PropertyDescriptor property = new PropertyDescriptor(propName, this.getClass());
             final Method method = property.getWriteMethod();

--- a/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriters.java
+++ b/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriters.java
@@ -40,7 +40,7 @@ public class ChronicleLogWriters {
     public static class IndexedExcerptAppenderProvider implements ExcerptAppenderProvider {
         private ExcerptAppender appender;
 
-        public IndexedExcerptAppenderProvider(final @NotNull Chronicle chronicle) {
+        public IndexedExcerptAppenderProvider(@NotNull final Chronicle chronicle) {
             try {
                 this.appender = chronicle.createAppender();
             } catch (IOException e) {
@@ -59,7 +59,7 @@ public class ChronicleLogWriters {
     public static class VanillaExcerptAppenderProvider implements ExcerptAppenderProvider {
         private final Chronicle chronicle;
 
-        public VanillaExcerptAppenderProvider(final @NotNull Chronicle chronicle) {
+        public VanillaExcerptAppenderProvider(@NotNull final Chronicle chronicle) {
             this.chronicle = chronicle;
         }
 
@@ -79,7 +79,7 @@ public class ChronicleLogWriters {
     //
     // *************************************************************************
 
-    public static abstract class AbstractChronicleLogWriter implements ChronicleLogWriter {
+    public abstract static class AbstractChronicleLogWriter implements ChronicleLogWriter {
 
         private final ExcerptAppenderProvider appenderProvider;
         private final Chronicle chronicle;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal