### PR TITLE
General code quality fix-1.

### DIFF
--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHelper.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHelper.java
@@ -47,6 +47,10 @@ public class ChronicleHelper {
         chronicleToJulLevelMap.put(ChronicleLogLevel.WARN , Level.WARNING);
         chronicleToJulLevelMap.put(ChronicleLogLevel.ERROR, Level.SEVERE);
     }
+    
+    private ChronicleHelper() {
+        
+    }
 
     public static ChronicleLogLevel getLogLevel(final LogRecord julRecord) {
         return getLogLevel(julRecord.getLevel());

--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
@@ -91,7 +91,7 @@ public abstract class AbstractChronicleAppender implements Appender, OptionHandl
     }
 
     @Override
-    public void finalize() {
+    protected void finalize() {
         // An appender might be closed then garbage collected. There is no
         // point in closing twice.
         if(this.writer == null) {

--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
@@ -38,7 +38,7 @@ public abstract class AbstractChronicleAppender
     private final FilterAttachableImpl<ILoggingEvent> filterAttachable;
 
     private String name;
-    private boolean started = false;
+    private boolean started;
 
     private String path;
 

--- a/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogManager.java
+++ b/logger/src/main/java/net/openhft/chronicle/logger/ChronicleLogManager.java
@@ -201,5 +201,9 @@ public class ChronicleLogManager {
 
     private static class Holder {
         private static final ChronicleLogManager INSTANCE = new ChronicleLogManager();
+        
+        private Holder() {
+            
+        }
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rules: 
pmd:RedundantFieldInitializer Redundant Field Initializer
squid:S1174 Object.finalize() should remain protected (versus public) when overriding
squid:S1118 Utility classes should not have public constructors

You can find more information about the issue here:
http://pmd.sourceforge.net/pmd-5.1.1/rules/java/optimizations.html
http://dev.eclipse.org/sonar/rules/show/squid:S1174
http://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal