### PR TITLE
Add support for SLF4J version 2.x

### DIFF
--- a/logger-slf4j-2/pom.xml
+++ b/logger-slf4j-2/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2014-2017  Chronicle Software
+  ~
+  ~ https://chronicle.software
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.openhft</groupId>
+        <artifactId>chronicle-logger</artifactId>
+        <version>4.22ea3-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>OpenHFT/Chronicle-Logger/logger-slf4j-2</name>
+    <artifactId>chronicle-logger-slf4j-2</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-logger-core</artifactId>
+        </dependency>
+
+        <!-- slf4j -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>-Xlint:deprecation</compilerArgument>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*PerfTest.java</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <project.build.directory>${project.build.directory}</project.build.directory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <!--
+                generate maven dependencies versions file that can be used later
+                to install the right bundle in test phase.
+
+                The file is:
+
+                    target/classes/META-INF/maven/dependencies.properties
+            -->
+            <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>OpenHFT :: ${project.artifactId}</Bundle-Name>
+                        <Bundle-Version>${project.version}</Bundle-Version>
+                        <Export-Package>net.openhft.chronicle.logger.slf4j.*</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <!--
+                      This execution makes sure that the manifest is available
+                      when the tests are executed
+                    -->
+                    <execution>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <scm>
+        <url>scm:git:git@github.com:OpenHFT/Chronicle-Logger.git</url>
+        <connection>scm:git:git@github.com:OpenHFT/Chronicle-Logger.git</connection>
+        <developerConnection>scm:git:git@github.com:OpenHFT/Chronicle-Logger.git</developerConnection>
+        <tag>master</tag>
+    </scm>
+
+</project>

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLogger.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLogger.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.logger.ChronicleLogLevel;
+import net.openhft.chronicle.logger.ChronicleLogWriter;
+import org.slf4j.helpers.MarkerIgnoringBase;
+
+public final class ChronicleLogger extends MarkerIgnoringBase {
+
+    private static final long serialVersionUID = 1L;
+    protected final ChronicleLogLevel level;
+    private final ChronicleLogWriter writer;
+
+    ChronicleLogger(final ChronicleLogWriter writer, final String name, final ChronicleLogLevel level) {
+        this.writer = writer;
+        this.name = name;
+        this.level = level;
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    ChronicleLogLevel getLevel() {
+        return this.level;
+    }
+
+    ChronicleLogWriter getWriter() {
+        return this.writer;
+    }
+
+    // *************************************************************************
+    // TRACE
+    // *************************************************************************
+
+    @Override
+    public boolean isTraceEnabled() {
+        return isLevelEnabled(ChronicleLogLevel.TRACE);
+    }
+
+    @Override
+    public void trace(String s) {
+        append(ChronicleLogLevel.TRACE, s);
+    }
+
+    @Override
+    public void trace(String s, Object o1) {
+        if (o1 instanceof Throwable) {
+            append(ChronicleLogLevel.TRACE, s, (Throwable) o1);
+
+        } else {
+            append(ChronicleLogLevel.TRACE, s, null, o1);
+        }
+    }
+
+    @Override
+    public void trace(String s, Object o1, Object o2) {
+        if (o2 instanceof Throwable) {
+            append(ChronicleLogLevel.TRACE, s, (Throwable) o2, o1);
+
+        } else {
+            append(ChronicleLogLevel.TRACE, s, null, o1, o2);
+        }
+    }
+
+    @Override
+    public void trace(String s, Object... objects) {
+        append(ChronicleLogLevel.TRACE, s, null, objects);
+    }
+
+    @Override
+    public void trace(String s, Throwable throwable) {
+        append(ChronicleLogLevel.TRACE, s, throwable);
+    }
+
+    // *************************************************************************
+    // DEBUG
+    // *************************************************************************
+
+    @Override
+    public boolean isDebugEnabled() {
+        return isLevelEnabled(ChronicleLogLevel.DEBUG);
+    }
+
+    @Override
+    public void debug(String s) {
+        append(ChronicleLogLevel.DEBUG, s);
+    }
+
+    @Override
+    public void debug(String s, Object o1) {
+        if (o1 instanceof Throwable) {
+            append(ChronicleLogLevel.DEBUG, s, (Throwable) o1);
+
+        } else {
+            append(ChronicleLogLevel.DEBUG, s, null, o1);
+        }
+    }
+
+    @Override
+    public void debug(String s, Object o1, Object o2) {
+        if (o2 instanceof Throwable) {
+            append(ChronicleLogLevel.DEBUG, s, (Throwable) o2, o1);
+
+        } else {
+            append(ChronicleLogLevel.DEBUG, s, null, o1, o2);
+        }
+    }
+
+    @Override
+    public void debug(String s, Object... objects) {
+        append(ChronicleLogLevel.DEBUG, s, null, objects);
+    }
+
+    @Override
+    public void debug(String s, Throwable throwable) {
+        append(ChronicleLogLevel.DEBUG, s, throwable);
+    }
+
+    // *************************************************************************
+    // INFO
+    // *************************************************************************
+
+    @Override
+    public boolean isInfoEnabled() {
+        return isLevelEnabled(ChronicleLogLevel.INFO);
+    }
+
+    @Override
+    public void info(String s) {
+        append(ChronicleLogLevel.INFO, s);
+    }
+
+    @Override
+    public void info(String s, Object o1) {
+        if (o1 instanceof Throwable) {
+            append(ChronicleLogLevel.INFO, s, (Throwable) o1);
+
+        } else {
+            append(ChronicleLogLevel.INFO, s, null, o1);
+        }
+    }
+
+    @Override
+    public void info(String s, Object o1, Object o2) {
+        if (o2 instanceof Throwable) {
+            append(ChronicleLogLevel.INFO, s, (Throwable) o2, o1);
+
+        } else {
+            append(ChronicleLogLevel.INFO, s, null, o1, o2);
+        }
+    }
+
+    @Override
+    public void info(String s, Object... objects) {
+        append(ChronicleLogLevel.INFO, s, null, objects);
+    }
+
+    @Override
+    public void info(String s, Throwable throwable) {
+        append(ChronicleLogLevel.INFO, s, throwable);
+    }
+
+    // *************************************************************************
+    // WARN
+    // *************************************************************************
+
+    @Override
+    public boolean isWarnEnabled() {
+        return isLevelEnabled(ChronicleLogLevel.WARN);
+    }
+
+    @Override
+    public void warn(String s) {
+        append(ChronicleLogLevel.WARN, s);
+    }
+
+    @Override
+    public void warn(String s, Object o1) {
+        if (o1 instanceof Throwable) {
+            append(ChronicleLogLevel.WARN, s, (Throwable) o1);
+
+        } else {
+            append(ChronicleLogLevel.WARN, s, null, o1);
+        }
+    }
+
+    @Override
+    public void warn(String s, Object o1, Object o2) {
+        if (o2 instanceof Throwable) {
+            append(ChronicleLogLevel.WARN, s, (Throwable) o2, o1);
+
+        } else {
+            append(ChronicleLogLevel.WARN, s, null, o1, o2);
+        }
+    }
+
+    @Override
+    public void warn(String s, Object... objects) {
+        append(ChronicleLogLevel.WARN, s, null, objects);
+    }
+
+    @Override
+    public void warn(String s, Throwable throwable) {
+        append(ChronicleLogLevel.WARN, s, throwable);
+    }
+
+    // *************************************************************************
+    // ERROR
+    // *************************************************************************
+
+    @Override
+    public boolean isErrorEnabled() {
+        return isLevelEnabled(ChronicleLogLevel.ERROR);
+    }
+
+    @Override
+    public void error(String s) {
+        append(ChronicleLogLevel.ERROR, s);
+    }
+
+    @Override
+    public void error(String s, Object o1) {
+        if (o1 instanceof Throwable) {
+            append(ChronicleLogLevel.ERROR, s, (Throwable) o1);
+
+        } else {
+            append(ChronicleLogLevel.ERROR, s, null, o1);
+        }
+    }
+
+    @Override
+    public void error(String s, Object o1, Object o2) {
+        if (o2 instanceof Throwable) {
+            append(ChronicleLogLevel.ERROR, s, (Throwable) o2, o1);
+
+        } else {
+            append(ChronicleLogLevel.ERROR, s, null, o1, o2);
+        }
+    }
+
+    @Override
+    public void error(String s, Object... objects) {
+        append(ChronicleLogLevel.ERROR, s, null, objects);
+    }
+
+    @Override
+    public void error(String s, Throwable throwable) {
+        append(ChronicleLogLevel.ERROR, s, throwable);
+    }
+
+    // *************************************************************************
+    // HELPERS
+    // *************************************************************************
+
+    private boolean isLevelEnabled(ChronicleLogLevel level) {
+        return level.isHigherOrEqualTo(this.level);
+    }
+
+    protected void append(ChronicleLogLevel level, String message) {
+        if (isLevelEnabled(level)) {
+            writer.write(
+                    level,
+                    System.currentTimeMillis(),
+                    Thread.currentThread().getName(),
+                    name,
+                    message,
+                    null);
+        }
+    }
+
+    protected void append(ChronicleLogLevel level, String message, Throwable throwable) {
+        if (isLevelEnabled(level)) {
+            writer.write(
+                    level,
+                    System.currentTimeMillis(),
+                    Thread.currentThread().getName(),
+                    name,
+                    message,
+                    throwable);
+        }
+    }
+
+    protected void append(ChronicleLogLevel level, String message, Throwable throwable, Object... args) {
+        if (isLevelEnabled(level)) {
+            writer.write(
+                    level,
+                    System.currentTimeMillis(),
+                    Thread.currentThread().getName(),
+                    name,
+                    message,
+                    throwable,
+                    args);
+        }
+    }
+}

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggerFactory.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggerFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.logger.ChronicleLogManager;
+import net.openhft.chronicle.logger.ChronicleLogWriter;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.helpers.NOPLogger;
+import org.slf4j.impl.SimpleLogger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * <p>Simple implementation of Logger that sends all enabled slf4j messages,
+ * for all defined loggers, to one or more VanillaChronicle..
+ * </p>
+ * <p>
+ * To configure this sl4j binding you need to specify the location of a properties
+ * files via system properties:
+ * </p>
+ * <code>-Dchronicle.logger.properties=${pathOfYourPropertiesFile}</code>
+ * <p>
+ * The following system properties are supported to configure the behavior of this
+ * logger:
+ * </p>
+ * <ul>
+ * <li><code>chronicle.logger.root.path</code></li>
+ * <li><code>chronicle.logger.root.level</code></li>
+ * <li><code>chronicle.logger.root.append</code></li>
+ * </ul>
+ */
+public class ChronicleLoggerFactory implements ILoggerFactory {
+    private final Map<String, Logger> loggers;
+    private final ChronicleLogManager manager;
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    /**
+     * c-tor
+     */
+    public ChronicleLoggerFactory() {
+        this.loggers = new ConcurrentHashMap<>();
+        this.manager = ChronicleLogManager.getInstance();
+    }
+
+    // *************************************************************************
+    // for testing
+    // *************************************************************************
+
+    /**
+     * Return an appropriate {@link ChronicleLogger} instance by name.
+     */
+    @Override
+    public Logger getLogger(String name) {
+        try {
+            return doGetLogger(name);
+        } catch (Exception e) {
+            System.err.println("Unable to initialize chronicle-logger-slf4j (" + name + ")\n  " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return NOPLogger.NOP_LOGGER;
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    synchronized void reload() {
+        this.loggers.clear();
+        this.manager.reload();
+    }
+
+    private synchronized Logger doGetLogger(String name) {
+        Logger logger = loggers.get(name);
+        if (logger == null) {
+            if (name != null && name.startsWith("net.openhft")) {
+                SimpleLogger.lazyInit();
+                logger = new SimpleLogger(name);
+            } else {
+                final ChronicleLogWriter writer = manager.getWriter(name);
+                logger = new ChronicleLogger(writer, name, manager.cfg().getLevel(name));
+            }
+            loggers.put(name, logger);
+        }
+
+        return logger;
+    }
+}
+

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
+ * Internal classes shall <em>never</em> be used directly.
+ * <p>
+ *  Specifically, the following actions (including, but not limited to) are not allowed
+ *  on internal classes and packages:
+ *  <ul>
+ *      <li>Casting to</li>
+ *      <li>Reflection of any kind</li>
+ *      <li>Explicit Serialize/deserialize</li>
+ *  </ul>
+ * <p>
+ * The classes in this package and any sub-package are subject to
+ * changes at any time for any reason.
+ */
+package net.openhft.chronicle.logger.slf4j2.internal;

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/ChronicleServiceProvider.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/ChronicleServiceProvider.java
@@ -1,0 +1,56 @@
+package org.slf4j.impl;
+
+import net.openhft.chronicle.logger.slf4j2.ChronicleLoggerFactory;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.helpers.NOPMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+public class ChronicleServiceProvider implements SLF4JServiceProvider {
+
+    /**
+     * Declare the version of the SLF4J API this implementation is compiled against.
+     * The value of this field is modified with each major release.
+     */
+    // to avoid constant folding by the compiler, this field must *not* be final
+    public static String REQUESTED_API_VERSION = "2.0.99"; // !final
+
+    public ChronicleServiceProvider() {}
+    /**
+     * The ILoggerFactory instance returned by the {@link #getLoggerFactory}
+     * method should always be the same object
+     */
+    private ILoggerFactory loggerFactory;
+
+    private IMarkerFactory markerFactory;
+    private MDCAdapter mdcAdapter;
+
+    @Override
+    public ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    @Override
+    public IMarkerFactory getMarkerFactory() {
+        return markerFactory;
+    }
+
+    @Override
+    public MDCAdapter getMDCAdapter() {
+        return mdcAdapter;
+    }
+
+    @Override
+    public String getRequestedApiVersion() {
+        return REQUESTED_API_VERSION;
+    }
+
+    @Override
+    public void initialize() {
+        loggerFactory = new ChronicleLoggerFactory();
+        markerFactory = new BasicMarkerFactory();
+        mdcAdapter = new NOPMDCAdapter();
+    }
+}

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/OutputChoice.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/OutputChoice.java
@@ -1,0 +1,55 @@
+package org.slf4j.impl;
+
+import java.io.PrintStream;
+
+/**
+ * This class encapsulates the user's choice of output target.
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ *
+ */
+class OutputChoice {
+
+    enum OutputChoiceType {
+        SYS_OUT, CACHED_SYS_OUT, SYS_ERR, CACHED_SYS_ERR, FILE;
+    }
+
+    final OutputChoiceType outputChoiceType;
+    final PrintStream targetPrintStream;
+
+    OutputChoice(OutputChoiceType outputChoiceType) {
+        if (outputChoiceType == OutputChoiceType.FILE) {
+            throw new IllegalArgumentException();
+        }
+        this.outputChoiceType = outputChoiceType;
+        if (outputChoiceType == OutputChoiceType.CACHED_SYS_OUT) {
+            this.targetPrintStream = System.out;
+        } else if (outputChoiceType == OutputChoiceType.CACHED_SYS_ERR) {
+            this.targetPrintStream = System.err;
+        } else {
+            this.targetPrintStream = null;
+        }
+    }
+
+    OutputChoice(PrintStream printStream) {
+        this.outputChoiceType = OutputChoiceType.FILE;
+        this.targetPrintStream = printStream;
+    }
+
+    PrintStream getTargetPrintStream() {
+        switch (outputChoiceType) {
+            case SYS_OUT:
+                return System.out;
+            case SYS_ERR:
+                return System.err;
+            case CACHED_SYS_ERR:
+            case CACHED_SYS_OUT:
+            case FILE:
+                return targetPrintStream;
+            default:
+                throw new IllegalArgumentException();
+        }
+
+    }
+
+}

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -1,0 +1,455 @@
+/**
+ * Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+import org.slf4j.event.LoggingEvent;
+import org.slf4j.helpers.LegacyAbstractLogger;
+import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.helpers.NormalizedParameters;
+import org.slf4j.spi.LocationAwareLogger;
+
+/**
+ * <p>
+ * Simple implementation of {@link Logger} that sends all enabled log messages,
+ * for all defined loggers, to the console ({@code System.err}). The following
+ * system properties are supported to configure the behavior of this logger:
+ *
+ *
+ * <ul>
+ * <li><code>org.slf4j.simpleLogger.logFile</code> - The output target which can
+ * be the <em>path</em> to a file, or the special values "System.out" and
+ * "System.err". Default is "System.err".</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.cacheOutputStream</code> - If the output
+ * target is set to "System.out" or "System.err" (see preceding entry), by
+ * default, logs will be output to the latest value referenced by
+ * <code>System.out/err</code> variables. By setting this parameter to true, the
+ * output stream will be cached, i.e. assigned once at initialization time and
+ * re-used independently of the current value referenced by
+ * <code>System.out/err</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.defaultLogLevel</code> - Default log level
+ * for all instances of SimpleLogger. Must be one of ("trace", "debug", "info",
+ * "warn", "error" or "off"). If not specified, defaults to "info".</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.log.<em>a.b.c</em></code> - Logging detail
+ * level for a SimpleLogger instance named "a.b.c". Right-side value must be one
+ * of "trace", "debug", "info", "warn", "error" or "off". When a SimpleLogger
+ * named "a.b.c" is initialized, its level is assigned from this property. If
+ * unspecified, the level of nearest parent logger will be used, and if none is
+ * set, then the value specified by
+ * <code>org.slf4j.simpleLogger.defaultLogLevel</code> will be used.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.showDateTime</code> - Set to
+ * <code>true</code> if you want the current date and time to be included in
+ * output messages. Default is <code>false</code></li>
+ *
+ * <li><code>org.slf4j.simpleLogger.dateTimeFormat</code> - The date and time
+ * format to be used in the output messages. The pattern describing the date and
+ * time format is defined by <a href=
+ * "http://docs.oracle.com/javase/1.5.0/docs/api/java/text/SimpleDateFormat.html">
+ * <code>SimpleDateFormat</code></a>. If the format is not specified or is
+ * invalid, the number of milliseconds since start up will be output.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.showThreadName</code> -Set to
+ * <code>true</code> if you want to output the current thread name. Defaults to
+ * <code>true</code>.</li>
+ *
+ * <li>(since version 1.7.33 and 2.0.0-alpha6) <code>org.slf4j.simpleLogger.showThreadId</code> -
+ * If you would like to output the current thread id, then set to
+ * <code>true</code>. Defaults to <code>false</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.showLogName</code> - Set to
+ * <code>true</code> if you want the Logger instance name to be included in
+ * output messages. Defaults to <code>true</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.showShortLogName</code> - Set to
+ * <code>true</code> if you want the last component of the name to be included
+ * in output messages. Defaults to <code>false</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.levelInBrackets</code> - Should the level
+ * string be output in brackets? Defaults to <code>false</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.warnLevelString</code> - The string value
+ * output for the warn level. Defaults to <code>WARN</code>.</li>
+ *
+ * </ul>
+ *
+ * <p>
+ * In addition to looking for system properties with the names specified above,
+ * this implementation also checks for a class loader resource named
+ * <code>"simplelogger.properties"</code>, and includes any matching definitions
+ * from this resource (if it exists).
+ *
+ *
+ * <p>
+ * With no configuration, the default output includes the relative time in
+ * milliseconds, thread name, the level, logger name, and the message followed
+ * by the line separator for the host. In log4j terms it amounts to the "%r [%t]
+ * %level %logger - %m%n" pattern.
+ *
+ * <p>
+ * Sample output follows.
+ *
+ *
+ * <pre>
+ * 176 [main] INFO examples.Sort - Populating an array of 2 elements in reverse order.
+ * 225 [main] INFO examples.SortAlgo - Entered the sort method.
+ * 304 [main] INFO examples.SortAlgo - Dump of integer array:
+ * 317 [main] INFO examples.SortAlgo - Element [0] = 0
+ * 331 [main] INFO examples.SortAlgo - Element [1] = 1
+ * 343 [main] INFO examples.Sort - The next log statement should be an error message.
+ * 346 [main] ERROR examples.SortAlgo - Tried to dump an uninitialized array.
+ *   at org.log4j.examples.SortAlgo.dump(SortAlgo.java:58)
+ *   at org.log4j.examples.Sort.main(Sort.java:64)
+ * 467 [main] INFO  examples.Sort - Exiting main method.
+ * </pre>
+ *
+ * <p>
+ * This implementation is heavily inspired by
+ * <a href="http://commons.apache.org/logging/">Apache Commons Logging</a>'s
+ * SimpleLog.
+ *
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Scott Sanders
+ * @author Rod Waldhoff
+ * @author Robert Burrell Donkin
+ * @author C&eacute;drik LIME
+ */
+public class SimpleLogger extends LegacyAbstractLogger {
+
+    private static final long serialVersionUID = -632788891211436180L;
+
+    private static final long START_TIME = System.currentTimeMillis();
+
+    protected static final int LOG_LEVEL_TRACE = LocationAwareLogger.TRACE_INT;
+    protected static final int LOG_LEVEL_DEBUG = LocationAwareLogger.DEBUG_INT;
+    protected static final int LOG_LEVEL_INFO = LocationAwareLogger.INFO_INT;
+    protected static final int LOG_LEVEL_WARN = LocationAwareLogger.WARN_INT;
+    protected static final int LOG_LEVEL_ERROR = LocationAwareLogger.ERROR_INT;
+
+    static char SP = ' ';
+    static final String TID_PREFIX = "tid=";
+
+
+    // The OFF level can only be used in configuration files to disable logging.
+    // It has
+    // no printing method associated with it in o.s.Logger interface.
+    protected static final int LOG_LEVEL_OFF = LOG_LEVEL_ERROR + 10;
+
+    private static boolean INITIALIZED = false;
+    static final SimpleLoggerConfiguration CONFIG_PARAMS = new SimpleLoggerConfiguration();
+
+    public static void lazyInit() {
+        if (INITIALIZED) {
+            return;
+        }
+        INITIALIZED = true;
+        init();
+    }
+
+    // external software might be invoking this method directly. Do not rename
+    // or change its semantics.
+    static void init() {
+        CONFIG_PARAMS.init();
+    }
+
+    /** The current log level */
+    protected int currentLogLevel = LOG_LEVEL_INFO;
+    /** The short name of this simple log instance */
+    private transient String shortLogName = null;
+
+    /**
+     * All system properties used by <code>SimpleLogger</code> start with this
+     * prefix
+     */
+    public static final String SYSTEM_PREFIX = "org.slf4j.simpleLogger.";
+
+    public static final String LOG_KEY_PREFIX = SimpleLogger.SYSTEM_PREFIX + "log.";
+
+    public static final String CACHE_OUTPUT_STREAM_STRING_KEY = SimpleLogger.SYSTEM_PREFIX + "cacheOutputStream";
+
+    public static final String WARN_LEVEL_STRING_KEY = SimpleLogger.SYSTEM_PREFIX + "warnLevelString";
+
+    public static final String LEVEL_IN_BRACKETS_KEY = SimpleLogger.SYSTEM_PREFIX + "levelInBrackets";
+
+    public static final String LOG_FILE_KEY = SimpleLogger.SYSTEM_PREFIX + "logFile";
+
+    public static final String SHOW_SHORT_LOG_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showShortLogName";
+
+    public static final String SHOW_LOG_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showLogName";
+
+    public static final String SHOW_THREAD_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showThreadName";
+
+    public static final String SHOW_THREAD_ID_KEY = SimpleLogger.SYSTEM_PREFIX + "showThreadId";
+
+    public static final String DATE_TIME_FORMAT_KEY = SimpleLogger.SYSTEM_PREFIX + "dateTimeFormat";
+
+    public static final String SHOW_DATE_TIME_KEY = SimpleLogger.SYSTEM_PREFIX + "showDateTime";
+
+    public static final String DEFAULT_LOG_LEVEL_KEY = SimpleLogger.SYSTEM_PREFIX + "defaultLogLevel";
+
+    public SimpleLogger(String name) {
+        this.name = name;
+
+        String levelString = recursivelyComputeLevelString();
+        if (levelString != null) {
+            this.currentLogLevel = SimpleLoggerConfiguration.stringToLevel(levelString);
+        } else {
+            this.currentLogLevel = CONFIG_PARAMS.defaultLogLevel;
+        }
+    }
+
+    String recursivelyComputeLevelString() {
+        String tempName = name;
+        String levelString = null;
+        int indexOfLastDot = tempName.length();
+        while ((levelString == null) && (indexOfLastDot > -1)) {
+            tempName = tempName.substring(0, indexOfLastDot);
+            levelString = CONFIG_PARAMS.getStringProperty(SimpleLogger.LOG_KEY_PREFIX + tempName, null);
+            indexOfLastDot = String.valueOf(tempName).lastIndexOf(".");
+        }
+        return levelString;
+    }
+
+    /**
+     * To avoid intermingling of log messages and associated stack traces, the two
+     * operations are done in a synchronized block.
+     *
+     * @param buf
+     * @param t
+     */
+    void write(StringBuilder buf, Throwable t) {
+        PrintStream targetStream = CONFIG_PARAMS.outputChoice.getTargetPrintStream();
+
+        synchronized (CONFIG_PARAMS) {
+            targetStream.println(buf.toString());
+            writeThrowable(t, targetStream);
+            targetStream.flush();
+        }
+
+    }
+
+    protected void writeThrowable(Throwable t, PrintStream targetStream) {
+        if (t != null) {
+            t.printStackTrace(targetStream);
+        }
+    }
+
+    private String getFormattedDate() {
+        Date now = new Date();
+        String dateText;
+        synchronized (CONFIG_PARAMS.dateFormatter) {
+            dateText = CONFIG_PARAMS.dateFormatter.format(now);
+        }
+        return dateText;
+    }
+
+    private String computeShortName() {
+        return name.substring(name.lastIndexOf(".") + 1);
+    }
+
+    // /**
+    // * For formatted messages, first substitute arguments and then log.
+    // *
+    // * @param level
+    // * @param format
+    // * @param arg1
+    // * @param arg2
+    // */
+    // private void formatAndLog(int level, String format, Object arg1, Object arg2) {
+    // if (!isLevelEnabled(level)) {
+    // return;
+    // }
+    // FormattingTuple tp = MessageFormatter.format(format, arg1, arg2);
+    // log(level, tp.getMessage(), tp.getThrowable());
+    // }
+
+    // /**
+    // * For formatted messages, first substitute arguments and then log.
+    // *
+    // * @param level
+    // * @param format
+    // * @param arguments
+    // * a list of 3 ore more arguments
+    // */
+    // private void formatAndLog(int level, String format, Object... arguments) {
+    // if (!isLevelEnabled(level)) {
+    // return;
+    // }
+    // FormattingTuple tp = MessageFormatter.arrayFormat(format, arguments);
+    // log(level, tp.getMessage(), tp.getThrowable());
+    // }
+
+    /**
+     * Is the given log level currently enabled?
+     *
+     * @param logLevel is this level enabled?
+     * @return whether the logger is enabled for the given level
+     */
+    protected boolean isLevelEnabled(int logLevel) {
+        // log level are numerically ordered so can use simple numeric
+        // comparison
+        return (logLevel >= currentLogLevel);
+    }
+
+    /** Are {@code trace} messages currently enabled? */
+    public boolean isTraceEnabled() {
+        return isLevelEnabled(LOG_LEVEL_TRACE);
+    }
+
+    /** Are {@code debug} messages currently enabled? */
+    public boolean isDebugEnabled() {
+        return isLevelEnabled(LOG_LEVEL_DEBUG);
+    }
+
+    /** Are {@code info} messages currently enabled? */
+    public boolean isInfoEnabled() {
+        return isLevelEnabled(LOG_LEVEL_INFO);
+    }
+
+    /** Are {@code warn} messages currently enabled? */
+    public boolean isWarnEnabled() {
+        return isLevelEnabled(LOG_LEVEL_WARN);
+    }
+
+    /** Are {@code error} messages currently enabled? */
+    public boolean isErrorEnabled() {
+        return isLevelEnabled(LOG_LEVEL_ERROR);
+    }
+
+    /**
+     * SimpleLogger's implementation of
+     * {@link org.slf4j.helpers.AbstractLogger#handleNormalizedLoggingCall(Level, Marker, String, Object[], Throwable) AbstractLogger#handleNormalizedLoggingCall}
+     * }
+     *
+     * @param level the SLF4J level for this event
+     * @param marker  The marker to be used for this event, may be null.
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param arguments  the array of arguments to be formatted, may be null
+     * @param throwable  The exception whose stack trace should be logged, may be null
+     */
+    @Override
+    protected void handleNormalizedLoggingCall(Level level, Marker marker, String messagePattern, Object[] arguments, Throwable throwable) {
+
+        List<Marker> markers = null;
+
+        if (marker != null) {
+            markers = new ArrayList<>();
+            markers.add(marker);
+        }
+
+        innerHandleNormalizedLoggingCall(level, markers, messagePattern, arguments, throwable);
+    }
+
+    private void innerHandleNormalizedLoggingCall(Level level, List<Marker> markers, String messagePattern, Object[] arguments, Throwable t) {
+
+        StringBuilder buf = new StringBuilder(32);
+
+        // Append date-time if so configured
+        if (CONFIG_PARAMS.showDateTime) {
+            if (CONFIG_PARAMS.dateFormatter != null) {
+                buf.append(getFormattedDate());
+                buf.append(SP);
+            } else {
+                buf.append(System.currentTimeMillis() - START_TIME);
+                buf.append(SP);
+            }
+        }
+
+        // Append current thread name if so configured
+        if (CONFIG_PARAMS.showThreadName) {
+            buf.append('[');
+            buf.append(Thread.currentThread().getName());
+            buf.append("] ");
+        }
+
+        if (CONFIG_PARAMS.showThreadId) {
+            buf.append(TID_PREFIX);
+            buf.append(Thread.currentThread().getId());
+            buf.append(SP);
+        }
+
+        if (CONFIG_PARAMS.levelInBrackets)
+            buf.append('[');
+
+        // Append a readable representation of the log level
+        String levelStr = level.name();
+        buf.append(levelStr);
+        if (CONFIG_PARAMS.levelInBrackets)
+            buf.append(']');
+        buf.append(SP);
+
+        // Append the name of the log instance if so configured
+        if (CONFIG_PARAMS.showShortLogName) {
+            if (shortLogName == null)
+                shortLogName = computeShortName();
+            buf.append(String.valueOf(shortLogName)).append(" - ");
+        } else if (CONFIG_PARAMS.showLogName) {
+            buf.append(String.valueOf(name)).append(" - ");
+        }
+
+        if (markers != null) {
+            buf.append(SP);
+            for (Marker marker : markers) {
+                buf.append(marker.getName()).append(SP);
+            }
+        }
+
+        String formattedMessage = MessageFormatter.basicArrayFormat(messagePattern, arguments);
+
+        // Append the message
+        buf.append(formattedMessage);
+
+        write(buf, t);
+    }
+
+    public void log(LoggingEvent event) {
+        int levelInt = event.getLevel().toInt();
+
+        if (!isLevelEnabled(levelInt)) {
+            return;
+        }
+
+        NormalizedParameters np = NormalizedParameters.normalize(event);
+
+        innerHandleNormalizedLoggingCall(event.getLevel(), event.getMarkers(), np.getMessage(), np.getArguments(), event.getThrowable());
+    }
+
+    @Override
+    protected String getFullyQualifiedCallerName() {
+        return null;
+    }
+
+}

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
@@ -1,0 +1,193 @@
+package org.slf4j.impl;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Properties;
+
+import org.slf4j.helpers.Util;
+import org.slf4j.impl.OutputChoice.OutputChoiceType;
+
+
+/**
+ * This class holds configuration values for {@link SimpleLogger}. The
+ * values are computed at runtime. See {@link SimpleLogger} documentation for
+ * more information.
+ *
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Scott Sanders
+ * @author Rod Waldhoff
+ * @author Robert Burrell Donkin
+ * @author C&eacute;drik LIME
+ *
+ * @since 1.7.25
+ */
+public class SimpleLoggerConfiguration {
+
+    private static final String CONFIGURATION_FILE = "simplelogger.properties";
+
+    static int DEFAULT_LOG_LEVEL_DEFAULT = SimpleLogger.LOG_LEVEL_INFO;
+    int defaultLogLevel = DEFAULT_LOG_LEVEL_DEFAULT;
+
+    private static final boolean SHOW_DATE_TIME_DEFAULT = false;
+    boolean showDateTime = SHOW_DATE_TIME_DEFAULT;
+
+    private static final String DATE_TIME_FORMAT_STR_DEFAULT = null;
+    private static String dateTimeFormatStr = DATE_TIME_FORMAT_STR_DEFAULT;
+
+    DateFormat dateFormatter = null;
+
+    private static final boolean SHOW_THREAD_NAME_DEFAULT = true;
+    boolean showThreadName = SHOW_THREAD_NAME_DEFAULT;
+
+    /**
+     * See https://jira.qos.ch/browse/SLF4J-499
+     * @since 1.7.33 and 2.0.0-alpha6
+     */
+    private static final boolean SHOW_THREAD_ID_DEFAULT = false;
+    boolean showThreadId = SHOW_THREAD_ID_DEFAULT;
+
+    final static boolean SHOW_LOG_NAME_DEFAULT = true;
+    boolean showLogName = SHOW_LOG_NAME_DEFAULT;
+
+    private static final boolean SHOW_SHORT_LOG_NAME_DEFAULT = false;
+    boolean showShortLogName = SHOW_SHORT_LOG_NAME_DEFAULT;
+
+    private static final boolean LEVEL_IN_BRACKETS_DEFAULT = false;
+    boolean levelInBrackets = LEVEL_IN_BRACKETS_DEFAULT;
+
+    private static final String LOG_FILE_DEFAULT = "System.err";
+    private String logFile = LOG_FILE_DEFAULT;
+    OutputChoice outputChoice = null;
+
+    private static final boolean CACHE_OUTPUT_STREAM_DEFAULT = false;
+    private boolean cacheOutputStream = CACHE_OUTPUT_STREAM_DEFAULT;
+
+    private static final String WARN_LEVELS_STRING_DEFAULT = "WARN";
+    String warnLevelString = WARN_LEVELS_STRING_DEFAULT;
+
+    private final Properties properties = new Properties();
+
+    void init() {
+        loadProperties();
+
+        String defaultLogLevelString = getStringProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, null);
+        if (defaultLogLevelString != null)
+            defaultLogLevel = stringToLevel(defaultLogLevelString);
+
+        showLogName = getBooleanProperty(SimpleLogger.SHOW_LOG_NAME_KEY, SimpleLoggerConfiguration.SHOW_LOG_NAME_DEFAULT);
+        showShortLogName = getBooleanProperty(SimpleLogger.SHOW_SHORT_LOG_NAME_KEY, SHOW_SHORT_LOG_NAME_DEFAULT);
+        showDateTime = getBooleanProperty(SimpleLogger.SHOW_DATE_TIME_KEY, SHOW_DATE_TIME_DEFAULT);
+        showThreadName = getBooleanProperty(SimpleLogger.SHOW_THREAD_NAME_KEY, SHOW_THREAD_NAME_DEFAULT);
+        showThreadId = getBooleanProperty(SimpleLogger.SHOW_THREAD_ID_KEY, SHOW_THREAD_ID_DEFAULT);
+        dateTimeFormatStr = getStringProperty(SimpleLogger.DATE_TIME_FORMAT_KEY, DATE_TIME_FORMAT_STR_DEFAULT);
+        levelInBrackets = getBooleanProperty(SimpleLogger.LEVEL_IN_BRACKETS_KEY, LEVEL_IN_BRACKETS_DEFAULT);
+        warnLevelString = getStringProperty(SimpleLogger.WARN_LEVEL_STRING_KEY, WARN_LEVELS_STRING_DEFAULT);
+
+        logFile = getStringProperty(SimpleLogger.LOG_FILE_KEY, logFile);
+
+        cacheOutputStream = getBooleanProperty(SimpleLogger.CACHE_OUTPUT_STREAM_STRING_KEY, CACHE_OUTPUT_STREAM_DEFAULT);
+        outputChoice = computeOutputChoice(logFile, cacheOutputStream);
+
+        if (dateTimeFormatStr != null) {
+            try {
+                dateFormatter = new SimpleDateFormat(dateTimeFormatStr);
+            } catch (IllegalArgumentException e) {
+                Util.report("Bad date format in " + CONFIGURATION_FILE + "; will output relative time", e);
+            }
+        }
+    }
+
+    private void loadProperties() {
+        // Add props from the resource simplelogger.properties
+        InputStream in = AccessController.doPrivileged((PrivilegedAction<InputStream>) () -> {
+            ClassLoader threadCL = Thread.currentThread().getContextClassLoader();
+            if (threadCL != null) {
+                return threadCL.getResourceAsStream(CONFIGURATION_FILE);
+            } else {
+                return ClassLoader.getSystemResourceAsStream(CONFIGURATION_FILE);
+            }
+        });
+        if (null != in) {
+            try {
+                properties.load(in);
+            } catch (java.io.IOException e) {
+                // ignored
+            } finally {
+                try {
+                    in.close();
+                } catch (java.io.IOException e) {
+                    // ignored
+                }
+            }
+        }
+    }
+
+    String getStringProperty(String name, String defaultValue) {
+        String prop = getStringProperty(name);
+        return (prop == null) ? defaultValue : prop;
+    }
+
+    boolean getBooleanProperty(String name, boolean defaultValue) {
+        String prop = getStringProperty(name);
+        return (prop == null) ? defaultValue : "true".equalsIgnoreCase(prop);
+    }
+
+    String getStringProperty(String name) {
+        String prop = null;
+        try {
+            prop = System.getProperty(name);
+        } catch (SecurityException e) {
+            // Ignore
+        }
+        return (prop == null) ? properties.getProperty(name) : prop;
+    }
+
+    static int stringToLevel(String levelStr) {
+        if ("trace".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_TRACE;
+        } else if ("debug".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_DEBUG;
+        } else if ("info".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_INFO;
+        } else if ("warn".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_WARN;
+        } else if ("error".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_ERROR;
+        } else if ("off".equalsIgnoreCase(levelStr)) {
+            return SimpleLogger.LOG_LEVEL_OFF;
+        }
+        // assume INFO by default
+        return SimpleLogger.LOG_LEVEL_INFO;
+    }
+
+    private static OutputChoice computeOutputChoice(String logFile, boolean cacheOutputStream) {
+        if ("System.err".equalsIgnoreCase(logFile))
+            if (cacheOutputStream)
+                return new OutputChoice(OutputChoiceType.CACHED_SYS_ERR);
+            else
+                return new OutputChoice(OutputChoiceType.SYS_ERR);
+        else if ("System.out".equalsIgnoreCase(logFile)) {
+            if (cacheOutputStream)
+                return new OutputChoice(OutputChoiceType.CACHED_SYS_OUT);
+            else
+                return new OutputChoice(OutputChoiceType.SYS_OUT);
+        } else {
+            try {
+                FileOutputStream fos = new FileOutputStream(logFile);
+                PrintStream printStream = new PrintStream(fos);
+                return new OutputChoice(printStream);
+            } catch (FileNotFoundException e) {
+                Util.report("Could not open [" + logFile + "]. Defaulting to System.err", e);
+                return new OutputChoice(OutputChoiceType.SYS_ERR);
+            }
+        }
+    }
+
+}

--- a/logger-slf4j-2/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
+++ b/logger-slf4j-2/src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider
@@ -1,0 +1,1 @@
+org.slf4j.impl.ChronicleServiceProvider

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggingConfigTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggingConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.logger.ChronicleLogConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class ChronicleLoggingConfigTest {
+    @Test
+    public void testLoadClasspathIndexed() {
+        System.setProperty("chronicle.logger.properties", "chronicle.logger.properties");
+        assertLoadsValidConfig();
+    }
+
+    private void assertLoadsValidConfig() {
+        ChronicleLogConfig config = ChronicleLogConfig.load();
+        assertNotNull("unable to load config", config);
+        assertNotNull("is not a valid config", config.getAppenderConfig());
+    }
+}

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleConfigurationTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleConfigurationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.logger.ChronicleLogConfig;
+import net.openhft.chronicle.logger.ChronicleLogLevel;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class Slf4jChronicleConfigurationTest extends Slf4jTestBase {
+
+    @Test
+    public void testLoadProperties() {
+        final String cfgPath = "chronicle.logger.properties";
+        final ChronicleLogConfig cfg = ChronicleLogConfig.load(cfgPath);
+
+        assertNotNull(cfg);
+
+        assertEquals(
+                new File(basePath("root")),
+                new File(cfg.getString(ChronicleLogConfig.KEY_PATH)));
+        assertEquals(
+                ChronicleLogLevel.DEBUG.toString(),
+                cfg.getString(ChronicleLogConfig.KEY_LEVEL).toUpperCase());
+        assertEquals("false", cfg.getString(ChronicleLogConfig.KEY_APPEND));
+        assertEquals(
+                new File(basePath("logger_1")),
+                new File(cfg.getString("logger_1", ChronicleLogConfig.KEY_PATH)));
+        assertEquals(
+                ChronicleLogLevel.INFO.toString(),
+                cfg.getString("logger_1", ChronicleLogConfig.KEY_LEVEL).toUpperCase());
+        assertEquals(
+                ChronicleLogLevel.DEBUG.toString(),
+                cfg.getString("readwrite", ChronicleLogConfig.KEY_LEVEL).toUpperCase());
+    }
+
+    @Test
+    public void testLoadConfig() {
+        final Properties properties = new Properties();
+        properties.setProperty("chronicle.logger.root.cfg.blockSize", "256");
+
+        final ChronicleLogConfig clc = ChronicleLogConfig.load(properties);
+        assertNotNull(clc.getAppenderConfig());
+
+        assertEquals(256, clc.getAppenderConfig().getBlockSize());
+    }
+}

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerPerfTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerPerfTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.core.io.IOTools;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Ignore
+public class Slf4jChronicleLoggerPerfTest extends Slf4jTestBase {
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    @Before
+    public void setUp() {
+        System.setProperty(
+                "chronicle.logger.properties",
+                "chronicle.logger.perf.properties");
+
+        getChronicleLoggerFactory().reload();
+    }
+
+    @After
+    public void tearDown() {
+        IOTools.deleteDirWithFiles(basePath());
+    }
+
+    // *************************************************************************
+    // Single Thread
+    // *************************************************************************
+
+    @Test
+    public void testSingleThreadLogging1() {
+        Thread.currentThread().setName("perf-plain");
+
+        final String testId = "perf-chronicle";
+        final Logger clogger = LoggerFactory.getLogger(testId);
+        final long items = 1000000;
+
+        warmup(clogger);
+
+        for (int s = 64; s <= 1024; s += 64) {
+            final String staticStr = StringUtils.leftPad("", s, 'X');
+
+            long cStart1 = System.nanoTime();
+
+            for (int i = 1; i <= items; i++) {
+                clogger.info(staticStr);
+            }
+
+            long cEnd1 = System.nanoTime();
+
+            System.out.printf("items=%03d size=%04d => chronology=%.3f ms, chronology-average=%.3f us\n",
+                    items,
+                    staticStr.length(),
+                    (cEnd1 - cStart1) / 1e6,
+                    (cEnd1 - cStart1) / items / 1e3);
+        }
+    }
+
+    @Test
+    public void testSingleThreadLogging2() {
+        Thread.currentThread().setName("perf-plain");
+
+        final String testId = "perf-chronicle";
+        final Logger clogger = LoggerFactory.getLogger(testId);
+        final long items = 1000000;
+        final String strFmt = StringUtils.leftPad("> v1={}, v2={}, v3={}", 32, 'X');
+
+        warmup(clogger);
+
+        for (int n = 0; n < 10; n++) {
+            long cStart1 = System.nanoTime();
+
+            for (int i = 1; i <= items; i++) {
+                clogger.info(strFmt, i, i * 10, i / 16);
+            }
+
+            long cEnd1 = System.nanoTime();
+
+            System.out.printf("items=%03d => chronology=%.3f ms, chronology-average=%.3f us\n",
+                    items,
+                    (cEnd1 - cStart1) / 1e6,
+                    (cEnd1 - cStart1) / items / 1e3);
+        }
+    }
+
+    // *************************************************************************
+    // Multi Thread
+    // *************************************************************************
+
+    @Test
+    public void testMultiThreadLogging() throws InterruptedException {
+        warmup(LoggerFactory.getLogger("perf-chronicle"));
+
+        final int RUNS = 1000000;
+        final int THREADS = 10;
+
+        for (int size : new int[]{64, 128, 256}) {
+            {
+                final long start = System.nanoTime();
+
+                ExecutorService es = Executors.newFixedThreadPool(THREADS);
+                for (int t = 0; t < THREADS; t++) {
+                    es.submit(new RunnableLogger(RUNS, size, "perf-chronicle"));
+                }
+
+                es.shutdown();
+                es.awaitTermination(5, TimeUnit.SECONDS);
+
+                final long time = System.nanoTime() - start;
+
+                System.out.printf("ChronicleLog.MT (runs=%d, min size=%03d, elapsed=%.3f ms) took an average of %.3f us per entry\n",
+                        RUNS,
+                        size,
+                        time / 1e6,
+                        time / 1e3 / (RUNS * THREADS)
+                );
+            }
+        }
+    }
+}

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.logger.ChronicleLogLevel;
+import net.openhft.chronicle.logger.DefaultChronicleLogWriter;
+import net.openhft.chronicle.queue.ChronicleQueue;
+import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.Wire;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.System.currentTimeMillis;
+import static org.junit.Assert.*;
+
+public class Slf4jChronicleLoggerTest extends Slf4jTestBase {
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    @NotNull
+    private static ChronicleQueue getChronicleQueue(String testId) {
+        return ChronicleQueue.singleBuilder(basePath(testId)).build();
+    }
+
+    @Before
+    public void setUp() {
+        System.setProperty(
+                "chronicle.logger.properties",
+                "chronicle.logger.properties"
+        );
+
+        getChronicleLoggerFactory().reload();
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    @After
+    public void tearDown() {
+
+        IOTools.deleteDirWithFiles(basePath());
+    }
+
+    @Test
+    public void testLoggerFactory() {
+        assertEquals(
+                getChronicleLoggerFactory().getClass(),
+                ChronicleLoggerFactory.class);
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    @Test
+    public void testLogger() {
+        Logger l1 = LoggerFactory.getLogger("slf4j-chronicle");
+        Logger l2 = LoggerFactory.getLogger("slf4j-chronicle");
+        Logger l3 = LoggerFactory.getLogger("logger_1");
+        Logger l4 = LoggerFactory.getLogger("readwrite");
+
+        assertNotNull(l1);
+        assertTrue(l1 instanceof ChronicleLogger);
+
+        assertNotNull(l2);
+        assertTrue(l2 instanceof ChronicleLogger);
+
+        assertNotNull(l3);
+        assertTrue(l3 instanceof ChronicleLogger);
+
+        assertNotNull(l4);
+        assertTrue(l4 instanceof ChronicleLogger);
+
+        assertEquals(l1, l2);
+        assertNotEquals(l1, l3);
+        assertNotEquals(l3, l4);
+        assertNotEquals(l1, l4);
+
+        ChronicleLogger cl1 = (ChronicleLogger) l1;
+
+        assertEquals(cl1.getLevel(), ChronicleLogLevel.DEBUG);
+        assertEquals(cl1.getName(), "slf4j-chronicle");
+        assertTrue(cl1.getWriter() instanceof DefaultChronicleLogWriter);
+
+        ChronicleLogger cl2 = (ChronicleLogger) l2;
+        assertEquals(cl2.getLevel(), ChronicleLogLevel.DEBUG);
+        assertEquals(cl2.getName(), "slf4j-chronicle");
+        assertTrue(cl2.getWriter() instanceof DefaultChronicleLogWriter);
+
+        ChronicleLogger cl3 = (ChronicleLogger) l3;
+        assertEquals(cl3.getLevel(), ChronicleLogLevel.INFO);
+        assertTrue(cl3.getWriter() instanceof DefaultChronicleLogWriter);
+        assertEquals(cl3.getName(), "logger_1");
+
+        ChronicleLogger cl4 = (ChronicleLogger) l4;
+        assertEquals(cl4.getLevel(), ChronicleLogLevel.DEBUG);
+        assertTrue(cl4.getWriter() instanceof DefaultChronicleLogWriter);
+        assertEquals(cl4.getName(), "readwrite");
+    }
+
+    @Test
+    public void testLogging() throws IOException {
+        final String testId = "readwrite";
+        final String threadId = testId + "-th";
+        final Logger logger = LoggerFactory.getLogger(testId);
+
+        IOTools.deleteDirWithFiles(basePath(testId));
+        Files.createDirectories(Paths.get(basePath(testId)));
+
+        Thread.currentThread().setName(threadId);
+
+        for (ChronicleLogLevel level : LOG_LEVELS) {
+            log(logger, level, "level is {}", level);
+        }
+
+        try (final ChronicleQueue cq = getChronicleQueue(testId)) {
+            net.openhft.chronicle.queue.ExcerptTailer tailer = cq.createTailer();
+            for (ChronicleLogLevel level : LOG_LEVELS) {
+                // logger configured to debug
+                if (level.isHigherOrEqualTo(ChronicleLogLevel.DEBUG)) {
+                    try (DocumentContext dc = tailer.readingDocument()) {
+                        Wire wire = dc.wire();
+                        assertNotNull("log not found for " + level, wire);
+                        assertTrue(wire.read("ts").int64() <= currentTimeMillis());
+                        assertEquals(level, wire.read("level").asEnum(ChronicleLogLevel.class));
+                        assertEquals(threadId, wire.read("threadName").text());
+                        assertEquals(testId, wire.read("loggerName").text());
+                        assertEquals("level is {}", wire.read("message").text());
+                        assertTrue(wire.hasMore());
+                        List<Object> args = new ArrayList<>();
+                        assertTrue(wire.hasMore());
+                        wire.read("args").sequence(args, (l, vi) -> {
+                            while (vi.hasNextSequenceItem()) {
+                                l.add(vi.object(Object.class));
+                            }
+                        });
+                        assertEquals(level, args.iterator().next());
+                        assertFalse(wire.hasMore());
+                    }
+                }
+            }
+            try (DocumentContext dc = tailer.readingDocument()) {
+                Wire wire = dc.wire();
+                assertNull(wire);
+            }
+
+            logger.debug("Throwable test 1", new UnsupportedOperationException());
+            logger.debug("Throwable test 2", new UnsupportedOperationException("Exception message"));
+
+            try (DocumentContext dc = tailer.readingDocument()) {
+                Wire wire = dc.wire();
+                assertNotNull(wire);
+                assertTrue(wire.read("ts").int64() <= currentTimeMillis());
+                assertEquals(ChronicleLogLevel.DEBUG, wire.read("level").asEnum(ChronicleLogLevel.class));
+                assertEquals(threadId, wire.read("threadName").text());
+                assertEquals(testId, wire.read("loggerName").text());
+                assertEquals("Throwable test 1", wire.read("message").text());
+                assertTrue(wire.hasMore());
+                assertTrue(wire.read("throwable").throwable(false) instanceof UnsupportedOperationException);
+                assertFalse(wire.hasMore());
+            }
+
+            try (DocumentContext dc = tailer.readingDocument()) {
+                Wire wire = dc.wire();
+                assertNotNull(wire);
+                assertTrue(wire.read("ts").int64() <= currentTimeMillis());
+                assertEquals(ChronicleLogLevel.DEBUG, wire.read("level").asEnum(ChronicleLogLevel.class));
+                assertEquals(threadId, wire.read("threadName").text());
+                assertEquals(testId, wire.read("loggerName").text());
+                assertEquals("Throwable test 2", wire.read("message").text());
+                assertTrue(wire.hasMore());
+                Throwable throwable = wire.read("throwable").throwable(false);
+                assertTrue(throwable instanceof UnsupportedOperationException);
+                assertEquals("Exception message", throwable.getMessage());
+                assertFalse(wire.hasMore());
+            }
+
+            try (DocumentContext dc = tailer.readingDocument()) {
+                Wire wire = dc.wire();
+                assertNull(wire);
+            }
+
+            logger.warn("Test object", new Object());
+
+            try (DocumentContext dc = tailer.readingDocument()) {
+                Wire wire = dc.wire();
+                assertNotNull(wire);
+                assertTrue(wire.read("ts").int64() <= currentTimeMillis());
+                assertEquals(ChronicleLogLevel.WARN, wire.read("level").asEnum(ChronicleLogLevel.class));
+                assertEquals(threadId, wire.read("threadName").text());
+                assertEquals(testId, wire.read("loggerName").text());
+                assertEquals("Test object", wire.read("message").text());
+                assertTrue(wire.hasMore());
+                List<Object> args = new ArrayList<>();
+                assertTrue(wire.hasMore());
+                wire.read("args").sequence(args, (l, vi) -> {
+                    while (vi.hasNextSequenceItem()) {
+                        l.add(vi.object(Object.class));
+                    }
+                });
+                assertTrue(((String) args.iterator().next()).contains("java.lang.Object@"));
+                assertFalse(wire.hasMore());
+            }
+        }
+    }
+}

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jTestBase.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jTestBase.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.logger.slf4j2;
+
+import net.openhft.chronicle.logger.ChronicleLogLevel;
+import net.openhft.chronicle.logger.slf4j2.ChronicleLoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.impl.ChronicleServiceProvider;
+
+class Slf4jTestBase {
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    static final ChronicleLogLevel[] LOG_LEVELS = ChronicleLogLevel.values();
+
+    static String basePath() {
+        String path = System.getProperty("java.io.tmpdir");
+        String sep = System.getProperty("file.separator");
+
+        if (!path.endsWith(sep)) {
+            path += sep;
+        }
+
+        return path + "chronicle-slf4j";
+    }
+
+    static String basePath(String loggerName) {
+        return basePath()
+                + System.getProperty("file.separator")
+                + loggerName;
+    }
+
+    static void log(Logger logger, ChronicleLogLevel level, String fmt, Object... args) {
+        switch (level) {
+            case TRACE:
+                logger.trace(fmt, args);
+                break;
+
+            case DEBUG:
+                logger.debug(fmt, args);
+                break;
+
+            case INFO:
+                logger.info(fmt, args);
+                break;
+
+            case WARN:
+                logger.warn(fmt, args);
+                break;
+
+            case ERROR:
+                logger.error(fmt, args);
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    static void warmup(Logger logger) {
+        for (int i = 0; i < 10; i++) {
+            logger.info("warmup");
+        }
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    /**
+     * @return the ChronicleLoggerFactory singleton
+     */
+    ChronicleLoggerFactory getChronicleLoggerFactory() {
+        ChronicleServiceProvider provider = new ChronicleServiceProvider();
+        provider.initialize();
+        return (ChronicleLoggerFactory) provider.getLoggerFactory();
+    }
+
+    // *************************************************************************
+    //
+    // *************************************************************************
+
+    protected final class RunnableLogger implements Runnable {
+        private final Logger logger;
+        private final int runs;
+        private final String fmt;
+        private final String fmtBase = " > val1={}, val2={}, val3={}";
+
+        public RunnableLogger(int runs, int pad, String loggerName) {
+            this.logger = LoggerFactory.getLogger(loggerName);
+            this.runs = runs;
+            this.fmt = StringUtils.rightPad(fmtBase, pad + fmtBase.length() - (4 + 8 + 8), "X");
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < this.runs; i++) {
+                this.logger.info(fmt, i, i * 7L, i / 16.0);
+            }
+        }
+    }
+}

--- a/logger-slf4j-2/src/test/resources/chronicle.logger.perf.properties
+++ b/logger-slf4j-2/src/test/resources/chronicle.logger.perf.properties
@@ -1,0 +1,23 @@
+#
+#     Copyright (C) 2014-2017  Chronicle Software
+#
+#     https://chronicle.software
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU Lesser General Public License as published by
+#     the Free Software Foundation, either version 3 of the License.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Lesser General Public License for more details.
+#
+#     You should have received a copy of the GNU Lesser General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+chronicle.logger.base             = ${java.io.tmpdir}/chronicle-slf4j
+
+chronicle.logger.root.path        = ${chronicle.logger.base}/perf
+chronicle.logger.root.level       = debug
+chronicle.logger.root.append      = false

--- a/logger-slf4j-2/src/test/resources/chronicle.logger.properties
+++ b/logger-slf4j-2/src/test/resources/chronicle.logger.properties
@@ -1,0 +1,37 @@
+#
+#     Copyright (C) 2014-2017  Chronicle Software
+#
+#     https://chronicle.software
+#
+#     This program is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU Lesser General Public License as published by
+#     the Free Software Foundation, either version 3 of the License.
+#
+#     This program is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU Lesser General Public License for more details.
+#
+#     You should have received a copy of the GNU Lesser General Public License
+#     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Common
+################################################################################
+
+chronicle.logger.base             = ${java.io.tmpdir}/chronicle-slf4j
+chronicle.logger.root.path        = ${chronicle.logger.base}/root
+chronicle.logger.root.level       = debug
+chronicle.logger.root.append      = false
+
+################################################################################
+# Loggers
+################################################################################
+
+# logger : Logger1
+chronicle.logger.logger_1.path          = ${chronicle.logger.base}/logger_1
+chronicle.logger.logger_1.level         = info
+
+# logger : impl
+chronicle.logger.readwrite.path         = ${chronicle.logger.base}/readwrite

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
         <module>logger-jul</module>
         <module>logger-jcl</module>
         <module>logger-slf4j</module>
+        <module>logger-slf4j-2</module>
         <module>logger-logback</module>
         <module>logger-log4j-1</module>
         <module>logger-log4j-2</module>


### PR DESCRIPTION
This mimics the existing SLF4J integration replacing the StaticLoggerBinder with ChronicleServiceProvider as per the 2.x API. Updated versions of the SLF4J imported classes.

Package naming follows the log4j 1/2 (I did not update the existing package to slf4j1).