### PR TITLE
Add usage docs for ChroniCat

### DIFF
--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
@@ -19,11 +19,22 @@ package net.openhft.chronicle.logger.tools;
 
 import net.openhft.chronicle.wire.WireType;
 
+/**
+ * Command line tool that prints the contents of a Chronicle log and exits.
+ *
+ * <p>Usage: {@code ChroniCat [-w <wireType>] <path>}.</p>
+ * <p>Example: {@code ChroniCat -w TEXT /var/log/myApp}</p>
+ */
 public final class ChroniCat {
 
     private ChroniCat() {
     }
 
+    /**
+     * Start the tool.
+     *
+     * @param args optional {@code -w <wireType>} then the path to the log directory
+     */
     public static void main(String[] args) {
         try {
 


### PR DESCRIPTION
## Summary
- document ChroniCat command line tool
- explain main method arguments and add example usage

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*