### PR TITLE
Document ChronicleLogger behaviour

### DIFF
--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
@@ -24,6 +24,13 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+/**
+ * Bridge between {@code java.util.logging} and Chronicle.
+ *
+ * <p>Extends {@link Logger} so JUL applications can write to a
+ * {@link ChronicleLogWriter}. The active level is controlled by
+ * {@link ChronicleLogLevel}.</p>
+*/
 class ChronicleLogger extends Logger {
 
     protected final String name;
@@ -84,6 +91,12 @@ class ChronicleLogger extends Logger {
         throw new UnsupportedOperationException("Cannot set parent logger");
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The record is translated to Chronicle format via
+     * {@link #append(LogRecord)}.</p>
+     */
     @Override
     public void log(final LogRecord record) {
         append(record);
@@ -238,6 +251,9 @@ class ChronicleLogger extends Logger {
         return level.isHigherOrEqualTo(this.level);
     }
 
+    /**
+     * Convert a JUL record to Chronicle format if the level permits.
+     */
     @SuppressWarnings("deprecation")
     protected void append(final LogRecord record) {
         final ChronicleLogLevel clevel = ChronicleHelper.getLogLevel(record);
@@ -253,6 +269,9 @@ class ChronicleLogger extends Logger {
         }
     }
 
+    /**
+     * Write a message without parameters if the level is enabled.
+     */
     protected void append(final Level level, String msg) {
         final ChronicleLogLevel clevel = ChronicleHelper.getLogLevel(level);
         if (isLoggable(clevel)) {
@@ -265,6 +284,9 @@ class ChronicleLogger extends Logger {
         }
     }
 
+    /**
+     * Write a message with parameters if the level is enabled.
+     */
     protected void append(final Level level, String msg, Object... params) {
         final ChronicleLogLevel clevel = ChronicleHelper.getLogLevel(level);
         if (isLoggable(clevel)) {
@@ -279,6 +301,9 @@ class ChronicleLogger extends Logger {
         }
     }
 
+    /**
+     * Write a message with a throwable if the level is enabled.
+     */
     protected void append(final Level level, String msg, Throwable thrown) {
         final ChronicleLogLevel clevel = ChronicleHelper.getLogLevel(level);
         if (isLoggable(clevel)) {
@@ -292,6 +317,9 @@ class ChronicleLogger extends Logger {
         }
     }
 
+    /**
+     * Logger implementation that ignores all messages.
+     */
     public static class Null extends ChronicleLogger {
         public static final ChronicleLogger INSTANCE = new Null();
 


### PR DESCRIPTION
## Summary
- document `ChronicleLogger` class
- explain how overridden `log` and `append` work
- describe the `Null` logger implementation

## Testing
- `mvn -q verify` *(fails: mvn not found)*