### PR TITLE
Document ChronicleAppender plugin usage

### DIFF
--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/ChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/ChronicleAppender.java
@@ -30,6 +30,15 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
+/**
+ * Log4j 2 appender that writes events to Chronicle Queue.
+ *
+ * <p>The class is registered as a plugin named {@code Chronicle} so it can be
+ * referenced from a Log4j 2 configuration file. The nested
+ * {@code chronicleCfg} element allows Chronicle Queue settings such as block
+ * size and roll cycle to be supplied.</p>
+ */
+
 @Plugin(
         name = "Chronicle",
         category = "Core",
@@ -49,6 +58,16 @@ public class ChronicleAppender extends AbstractChronicleAppender {
     //
     // *************************************************************************
 
+    /**
+     * Factory used by the plugin framework to create the appender.
+     *
+     * @param name mandatory appender name
+     * @param path Chronicle Queue path
+     * @param wireType optional queue wire type
+     * @param chronicleConfig optional queue configuration
+     * @param filter optional filter
+     * @return the configured appender or {@code null} when name or path are missing
+     */
     @PluginFactory
     public static ChronicleAppender createAppender(
             @PluginAttribute("name") final String name,
@@ -69,6 +88,9 @@ public class ChronicleAppender extends AbstractChronicleAppender {
         return new ChronicleAppender(name, filter, path, wireType, chronicleConfig);
     }
 
+    /**
+     * Writes the event to the Chronicle writer.
+     */
     @Override
     public void doAppend(@NotNull final LogEvent event, @NotNull final ChronicleLogWriter writer) {
         writer.write(
@@ -85,11 +107,15 @@ public class ChronicleAppender extends AbstractChronicleAppender {
     protected ChronicleLogWriter createWriter() throws IOException {
         return new DefaultChronicleLogWriter(config.build(getPath(), getWireType()));
     }
-
     // *************************************************************************
     //
     // *************************************************************************
 
+    /**
+     * Returns the Chronicle configuration backing this appender.
+     *
+     * @return the configuration instance
+     */
     protected LogAppenderConfig getChronicleConfig() {
         return this.config;
     }


### PR DESCRIPTION
## Summary
- document Chronicle appender as a Log4j2 plugin
- describe Chronicle configuration via `chronicleCfg`
- add Javadoc for `createAppender`, `doAppend` and `getChronicleConfig`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*