### PR TITLE
Document log levels and helper methods

### DIFF
--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogLevel.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogLevel.java
@@ -19,6 +19,20 @@ package net.openhft.chronicle.logger;
 
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Levels used by Chronicle Logger.
+ *
+ * <p>Each level has an integer value:
+ * <ul>
+ *     <li>ERROR = 50</li>
+ *     <li>WARN = 40</li>
+ *     <li>INFO = 30</li>
+ *     <li>DEBUG = 20</li>
+ *     <li>TRACE = 10</li>
+ * </ul>
+ * A higher value represents a more severe event.
+ */
+
 public enum ChronicleLogLevel {
     ERROR(50, "ERROR"),
     WARN(40, "WARN"),
@@ -41,6 +55,13 @@ public enum ChronicleLogLevel {
         this.levelStr = levelStr;
     }
 
+    /**
+     * Parses a textual level name.
+     *
+     * @param levelStr case-insensitive name such as {@code "INFO"}
+     * @return the matching level
+     * @throws IllegalArgumentException if the name is unknown
+     */
     public static ChronicleLogLevel fromStringLevel(final CharSequence levelStr) {
         if (levelStr != null) {
             for (ChronicleLogLevel cll : VALUES) {
@@ -76,6 +97,9 @@ public enum ChronicleLogLevel {
         return true;
     }
 
+    /**
+     * Tests whether this level is at least as severe as the given level.
+     */
     public boolean isHigherOrEqualTo(final ChronicleLogLevel presumablyLowerLevel) {
         return levelInt >= presumablyLowerLevel.levelInt;
     }


### PR DESCRIPTION
## Summary
- document `ChronicleLogLevel` values and their numeric forms
- explain `fromStringLevel` and `isHigherOrEqualTo`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*