### PR TITLE
Add Javadoc for DefaultChronicleLogWriter

### DIFF
--- a/logger-core/src/main/java/net/openhft/chronicle/logger/DefaultChronicleLogWriter.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/DefaultChronicleLogWriter.java
@@ -26,6 +26,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.text.SimpleDateFormat;
 
+/**
+ * Writes log entries to a {@link ChronicleQueue}.
+ * Each log event is serialised to the queue using the configured wire type.
+ */
 public class DefaultChronicleLogWriter implements ChronicleLogWriter {
 
     private static final ThreadLocal<Boolean> REENTRANCY_FLAG = ThreadLocal.withInitial(() -> false);
@@ -33,6 +37,11 @@ public class DefaultChronicleLogWriter implements ChronicleLogWriter {
 
     private final ChronicleQueue cq;
 
+    /**
+     * Creates a writer that appends log entries to the supplied queue.
+     *
+     * @param cq the target queue, not {@code null}
+     */
     public DefaultChronicleLogWriter(@NotNull ChronicleQueue cq) {
         this.cq = cq;
     }
@@ -42,6 +51,15 @@ public class DefaultChronicleLogWriter implements ChronicleLogWriter {
         cq.close();
     }
 
+    /**
+     * Records a log event without a throwable or arguments.
+     *
+     * @param level      the severity level
+     * @param timestamp  epoch time in milliseconds
+     * @param threadName name of the emitting thread
+     * @param loggerName name of the logger
+     * @param message    formatted message text
+     */
     @Override
     public void write(
             final ChronicleLogLevel level,
@@ -52,6 +70,17 @@ public class DefaultChronicleLogWriter implements ChronicleLogWriter {
         write(level, timestamp, threadName, loggerName, message, null);
     }
 
+    /**
+     * Records a log event with optional throwable and arguments.
+     *
+     * @param level      the severity level
+     * @param timestamp  epoch time in milliseconds
+     * @param threadName name of the emitting thread
+     * @param loggerName name of the logger
+     * @param message    formatted message text
+     * @param throwable  associated exception, may be {@code null}
+     * @param args       application-specific values to serialise
+     */
     @Override
     public void write(
             final ChronicleLogLevel level,


### PR DESCRIPTION
## Notes
- `mvn -q verify` failed: `mvn` command not found.

## Summary
- document `DefaultChronicleLogWriter` as writing to a Chronicle Queue
- document the constructor
- document both `write` methods
