### PR TITLE
Clarify volatility of internal packages

### DIFF
--- a/logger-core/src/main/java/net/openhft/chronicle/logger/internal/package-info.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/internal/package-info.java
@@ -12,5 +12,9 @@
  * <p>
  * The classes in this package and any sub-package are subject to
  * changes at any time for any reason.
+ * <p>
+ * Chronicle offers no binary or source compatibility for these
+ * internal types. They may be renamed, removed or altered without
+ * notice, even in a patch release.
  */
 package net.openhft.chronicle.logger.internal;


### PR DESCRIPTION
## Summary
- expand the `package-info.java` Javadoc to warn users about lack of compatibility guarantees

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*