### PR TITLE
Clarify logback internal package Javadoc

### DIFF
--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/internal/package-info.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/internal/package-info.java
@@ -1,5 +1,5 @@
 /**
- * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
+ * This package and any sub-package contain classes strictly for internal use by this Chronicle library.
  * Internal classes shall <em>never</em> be used directly.
  * <p>
  *  Specifically, the following actions (including, but not limited to) are not allowed
@@ -7,7 +7,7 @@
  *  <ul>
  *      <li>Casting to</li>
  *      <li>Reflection of any kind</li>
- *      <li>Explicit Serialize/deserialize</li>
+ *      <li>Explicit serialise/deserialise</li>
  *  </ul>
  * <p>
  * The classes in this package and any sub-package are subject to


### PR DESCRIPTION
## Summary
- state that the logback internal package is strictly for internal use
- use British spelling for serialise/deserialise

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*