### PR TITLE
Clarify unsupported status for Log4j 1 internals

### DIFF
--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/internal/package-info.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/internal/package-info.java
@@ -1,6 +1,7 @@
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
  * Internal classes shall <em>never</em> be used directly.
+ * Direct use of these classes is unsupported and may break without notice.
  * <p>
  *  Specifically, the following actions (including, but not limited to) are not allowed
  *  on internal classes and packages:


### PR DESCRIPTION
## Summary
- emphasise that direct use of Log4j 1 internal classes is unsupported

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*