### PR TITLE
Document API stability for internal packages

### DIFF
--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/internal/package-info.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/internal/package-info.java
@@ -11,6 +11,6 @@
  *  </ul>
  * <p>
  * The classes in this package and any sub-package are subject to
- * changes at any time for any reason.
+ * changes at any time for any reason. API stability is not guaranteed.
  */
 package net.openhft.chronicle.logger.log4j2.internal;


### PR DESCRIPTION
## Summary
- clarify the package-info for log4j2 internal packages

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*