### PR TITLE
Clarify JUL internal package stability

### DIFF
--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/internal/package-info.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/internal/package-info.java
@@ -10,7 +10,7 @@
  *      <li>Explicit Serialize/deserialize</li>
  *  </ul>
  * <p>
- * The classes in this package and any sub-package are subject to
- * changes at any time for any reason.
+ * The classes in this package and any sub-package may change
+ * without notice and can differ between releases.
  */
 package net.openhft.chronicle.logger.jul.internal;


### PR DESCRIPTION
## Summary
- warn users that classes under `logger-jul` internal packages may change between releases

## Testing
- `mvn -q verify` *(failed: `mvn` not found)*