### PR TITLE
Clarify SLF4J internal usage restrictions

### DIFF
--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/internal/package-info.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/internal/package-info.java
@@ -12,5 +12,6 @@
  * <p>
  * The classes in this package and any sub-package are subject to
  * changes at any time for any reason.
+ * Applications must not depend on them.
  */
 package net.openhft.chronicle.logger.slf4j.internal;


### PR DESCRIPTION
## Summary
- update the SLF4J internal package documentation
- state that applications must not depend on internal classes

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*