### PR TITLE
Document potential incompatibility in slf4j2 internals

### DIFF
--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
@@ -12,5 +12,7 @@
  * <p>
  * The classes in this package and any sub-package are subject to
  * changes at any time for any reason.
+ * <p>
+ * Later versions may not remain compatible with the current API.
  */
 package net.openhft.chronicle.logger.slf4j2.internal;


### PR DESCRIPTION
## Summary
- note that slf4j2 internals may not remain compatible with future versions

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*