### PR TITLE
Clarify internal tools are not public API

### DIFF
--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/internal/package-info.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/internal/package-info.java
@@ -1,6 +1,6 @@
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
- * Internal classes shall <em>never</em> be used directly.
+ * These utilities are not part of the public API and shall <em>never</em> be used directly.
  * <p>
  *  Specifically, the following actions (including, but not limited to) are not allowed
  *  on internal classes and packages:


### PR DESCRIPTION
## Summary
- update internal package header to state explicitly it's not a public API

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*