### PR TITLE
Clarify OutputChoice usage in Javadoc

### DIFF
--- a/logger-slf4j/src/main/java/org/slf4j/impl/OutputChoice.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/OutputChoice.java
@@ -3,10 +3,19 @@ package org.slf4j.impl;
 import java.io.PrintStream;
 
 /**
- * This class encapsulates the user's choice of output target.
+ * Encapsulates the user's choice of output target.
+ *
+ * <p>The {@link OutputChoiceType} is selected by
+ * {@link SimpleLoggerConfiguration}. Examples:
+ * <ul>
+ * <li>{@code SYS_OUT} uses {@link System#out} directly.</li>
+ * <li>{@code CACHED_SYS_OUT} keeps a cached {@link System#out}.</li>
+ * <li>{@code SYS_ERR} uses {@link System#err} directly.</li>
+ * <li>{@code CACHED_SYS_ERR} keeps a cached {@link System#err}.</li>
+ * <li>{@code FILE} writes to a supplied {@link PrintStream}.</li>
+ * </ul>
  *
  * @author Ceki G&uuml;lc&uuml;
- *
  */
 class OutputChoice {
 


### PR DESCRIPTION
## Summary
- document how each OutputChoiceType is selected

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*