### PR TITLE
Add Javadoc for ChronicleLogProcessor

### DIFF
--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogProcessor.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogProcessor.java
@@ -20,7 +20,23 @@ package net.openhft.chronicle.logger.tools;
 import net.openhft.chronicle.logger.ChronicleLogLevel;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Callback used by {@link ChronicleLogReader} to consume log entries.
+ * Implementations may print, store or filter the supplied data.
+ */
 public interface ChronicleLogProcessor {
+
+    /**
+     * Handle one log event produced by a {@link ChronicleLogWriter}.
+     *
+     * @param timestamp  epoch time in milliseconds
+     * @param level      severity of the event
+     * @param loggerName name of the logger that created the entry
+     * @param threadName name of the thread that wrote the entry
+     * @param message    message pattern, may contain "{}" placeholders
+     * @param throwable  optional stack trace, may be {@code null}
+     * @param args       argument values referenced by the message pattern
+     */
     void process(
             final long timestamp,
             final ChronicleLogLevel level,


### PR DESCRIPTION
## Summary
- document expected behaviour of `ChronicleLogProcessor`

## Testing
- `mvn -q verify` *(fails: command not found)*