### PR TITLE
Add Javadoc for binary appender test

### DIFF
--- a/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleBinaryAppenderTest.java
+++ b/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleBinaryAppenderTest.java
@@ -38,6 +38,10 @@ import java.util.List;
 import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.*;
 
+/**
+ * Validates that the Logback binary appender records each field in the
+ * chronicle queue and handles exceptions correctly.
+ */
 public class LogbackChronicleBinaryAppenderTest extends LogbackTestBase {
     @NotNull
     private static ChronicleQueue getChronicleQueue(String testId) {
@@ -57,6 +61,12 @@ public class LogbackChronicleBinaryAppenderTest extends LogbackTestBase {
         IOTools.deleteDirWithFiles(rootPath());
     }
 
+    /**
+     * Writes log events and confirms that each queue entry contains the
+     * expected fields and throwable data.
+     *
+     * @throws IOException if the queue directory cannot be created
+     */
     @Test
     public void testBinaryAppender() throws IOException {
         final String testId = "binary-chronicle";


### PR DESCRIPTION
## Summary
- document the purpose of `LogbackChronicleBinaryAppenderTest`
- describe the assertions and exception handling in the test method

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*