### PR TITLE
Do not merge: trial Logback 1.3.16 with SLF4J 2.0.17

### DIFF
--- a/logger-logback/pom.xml
+++ b/logger-logback/pom.xml
@@ -39,10 +39,11 @@
             <artifactId>chronicle-logger-core</artifactId>
         </dependency>
 
-        <!-- slf4j -->
+        <!-- slf4j - version 2.0.x required by logback 1.3.x -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
         </dependency>
 
         <!-- logback -->

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,21 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <!-- Logback versions - Java 8 compatible (1.3.x series) -->
+            <!-- Version 1.3.16 addresses CVE-2025-11226 -->
+            <!-- Requires SLF4J 2.0.x -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.3.16</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.3.16</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Experiment with Logback Core and Classic 1.3.16 in dependency management and an explicit SLF4J API 2.0.17 dependency in the Logback integration module.

Experimental - do not merge. Qualify the intended Java 8 configuration, provider/binding selection and real logging consumers before adopting these coordinates. Recorded CI alone does not settle the compatibility questions.

Validation: the diff and recorded review/check history were inspected at `1fa0615c06bc`. No build, test or benchmark was rerun for this metadata edit. Recorded commit statuses: 9 success.
