### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014-2025 chronicle.software
+   Copyright 2014-2026 chronicle.software
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/benchmark/src/main/java/net/openhft/Lo4J2PerfTest.java
+++ b/benchmark/src/main/java/net/openhft/Lo4J2PerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogConfig.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogLevel.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogManager.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriter.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLoggerFactoryControl.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/ChronicleLoggerFactoryControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/DefaultChronicleLogWriter.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/DefaultChronicleLogWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/LogAppenderConfig.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/LogAppenderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-core/src/main/java/net/openhft/chronicle/logger/internal/package-info.java
+++ b/logger-core/src/main/java/net/openhft/chronicle/logger/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-core/src/test/java/net/openhft/chronicle/logger/DefaultChronicleLogWriterTest.java
+++ b/logger-core/src/test/java/net/openhft/chronicle/logger/DefaultChronicleLogWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger;
 

--- a/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/ChronicleLogger.java
+++ b/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/ChronicleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jcl;
 

--- a/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/ChronicleLoggerFactory.java
+++ b/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/ChronicleLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jcl;
 

--- a/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/internal/package-info.java
+++ b/logger-jcl/src/main/java/net/openhft/chronicle/logger/jcl/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes

--- a/logger-jcl/src/test/java/net/openhft/chronicle/logger/jcl/JclChronicleLoggerTest.java
+++ b/logger-jcl/src/test/java/net/openhft/chronicle/logger/jcl/JclChronicleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jcl;
 

--- a/logger-jcl/src/test/java/net/openhft/chronicle/logger/jcl/JclTestBase.java
+++ b/logger-jcl/src/test/java/net/openhft/chronicle/logger/jcl/JclTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jcl;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/AbstractChronicleHandler.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/AbstractChronicleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHandler.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHandlerConfig.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHandlerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHelper.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLoggerManager.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/ChronicleLoggerManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/internal/package-info.java
+++ b/logger-jul/src/main/java/net/openhft/chronicle/logger/jul/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulHandlerChronicleTest.java
+++ b/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulHandlerChronicleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulHandlerTestBase.java
+++ b/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulHandlerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulLoggerChronicleTest.java
+++ b/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulLoggerChronicleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulLoggerTestBase.java
+++ b/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulLoggerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulTestBase.java
+++ b/logger-jul/src/test/java/net/openhft/chronicle/logger/jul/JulTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.jul;
 

--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/AbstractChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j1;
 

--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/ChronicleAppender.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/ChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j1;
 

--- a/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/internal/package-info.java
+++ b/logger-log4j-1/src/main/java/net/openhft/chronicle/logger/log4j1/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Log4j1ChronicleLogTest.java
+++ b/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Log4j1ChronicleLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j1;
 

--- a/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Log4j1TestBase.java
+++ b/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Log4j1TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j1;
 

--- a/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Slf4jBridgeChronicleLogTest.java
+++ b/logger-log4j-1/src/test/java/net/openhft/chronicle/logger/log4j1/Slf4jBridgeChronicleLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j1;
 

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/AbstractChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j2;
 

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/ChronicleAppender.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/ChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j2;
 

--- a/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/internal/package-info.java
+++ b/logger-log4j-2/src/main/java/net/openhft/chronicle/logger/log4j2/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2BinaryTest.java
+++ b/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2BinaryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j2;
 

--- a/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2TestBase.java
+++ b/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2TestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j2;
 

--- a/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2VulnerabilityTest.java
+++ b/logger-log4j-2/src/test/java/net/openhft/chronicle/logger/log4j2/Log4j2VulnerabilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.log4j2;
 

--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/AbstractChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/ChronicleAppender.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/ChronicleAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/internal/package-info.java
+++ b/logger-logback/src/main/java/net/openhft/chronicle/logger/logback/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any sub-package contain classes strictly for internal use by this Chronicle library.

--- a/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleBinaryAppenderTest.java
+++ b/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleBinaryAppenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleProgrammaticConfigTest.java
+++ b/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackChronicleProgrammaticConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackIndexedChronicleConfigTest.java
+++ b/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackIndexedChronicleConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackTestBase.java
+++ b/logger-logback/src/test/java/net/openhft/chronicle/logger/logback/LogbackTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.logback;
 

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLogger.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggerFactory.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
+++ b/logger-slf4j-2/src/main/java/net/openhft/chronicle/logger/slf4j2/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/ChronicleServiceProvider.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/ChronicleServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/OutputChoice.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/OutputChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)

--- a/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
+++ b/logger-slf4j-2/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggingConfigTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/ChronicleLoggingConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleConfigurationTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerPerfTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jChronicleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jProviderHealthCheckTest.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jProviderHealthCheckTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jTestBase.java
+++ b/logger-slf4j-2/src/test/java/net/openhft/chronicle/logger/slf4j2/Slf4jTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j2;
 

--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLogger.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerFactory.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/internal/package-info.java
+++ b/logger-slf4j/src/main/java/net/openhft/chronicle/logger/slf4j/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-slf4j/src/main/java/org/slf4j/impl/OutputChoice.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/OutputChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /*
  * Copyright (c) 2004-2012 QOS.ch

--- a/logger-slf4j/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/SimpleLoggerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
+++ b/logger-slf4j/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package org.slf4j.impl;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerBehaviourTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggerBehaviourTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggingConfigTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/ChronicleLoggingConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleConfigurationTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleLoggerPerfTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleLoggerPerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleLoggerTest.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jChronicleLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jTestBase.java
+++ b/logger-slf4j/src/test/java/net/openhft/chronicle/logger/slf4j/Slf4jTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.slf4j;
 

--- a/logger-tools/pom.xml
+++ b/logger-tools/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniCat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTail.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChroniTail.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogProcessor.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogReader.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/ChronicleLogReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/internal/package-info.java
+++ b/logger-tools/src/main/java/net/openhft/chronicle/logger/tools/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/logger-tools/src/test/java/net/openhft/chronicle/logger/tools/ChronicleCliToolsTest.java
+++ b/logger-tools/src/test/java/net/openhft/chronicle/logger/tools/ChronicleCliToolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/logger-tools/src/test/java/net/openhft/chronicle/logger/tools/ChronicleLogReaderTest.java
+++ b/logger-tools/src/test/java/net/openhft/chronicle/logger/tools/ChronicleLogReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.logger.tools;
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <jacoco.line.coverage>0.80</jacoco.line.coverage>
         <jacoco.branch.coverage>0.70</jacoco.branch.coverage>
     </properties>


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)