### PR TITLE
docs: replace above-U+00FF characters with 8-bit equivalents

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ Today most programs require the logging of large amounts of data, especially in 
 regulatory requirement. Loggers can affect your system performance, therefore logging is sometimes kept to a minimum.
 With Chronicle Logger we aim to minimize logging overhead, freeing your system to focus on the business logic.
 
-Chronicle logger supports most of the standard logging API’s including: 
+Chronicle logger supports most of the standard logging API's including: 
 
 * <<chronicle-logger-slf4j, SLF4J>>
 * <<chronicle-logger-logback, Logback>>

--- a/src/main/docs/code-review-playbook.adoc
+++ b/src/main/docs/code-review-playbook.adoc
@@ -4,7 +4,7 @@
 == Purpose
 
 This playbook lists the static-analysis and coverage checks executed by the
-`code-review` Maven profile so reviewers can reproduce the pipeline locally on the project’s supported JDKs.
+`code-review` Maven profile so reviewers can reproduce the pipeline locally on the project's supported JDKs.
 
 == Supported JDKs
 

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -7,8 +7,8 @@ Context::
 Decision Statement::
 * Chronicle Logger adopts the Nine-Box schema (FN, NF-P, NF-S, NF-O, DOC, OPS, TEST, RISK) with scope prefix `CLG` for all requirements and decisions.
 Alternatives Considered::
-* Free-form numbering – low effort, but tooling and audits cannot map entries consistently.
-* Per-module numbering – splits visibility across bindings and complicates shared obligations.
+* Free-form numbering - low effort, but tooling and audits cannot map entries consistently.
+* Per-module numbering - splits visibility across bindings and complicates shared obligations.
 Rationale for Decision::
 * Aligns Chronicle Logger with company-wide guidance and enables cross-linking with test and benchmark artefacts.
 * Simplifies audit checks for requirement coverage.
@@ -26,8 +26,8 @@ Context::
 Decision Statement::
 * All bindings must require an explicit Chronicle Queue path from configuration and fail fast with a warning if the directory is absent or unwritable.
 Alternatives Considered::
-* Auto-create directories – masks configuration errors and may violate deployment policies.
-* Fallback to in-memory logging – deviates from Chronicle Logger’s persistence contract.
+* Auto-create directories - masks configuration errors and may violate deployment policies.
+* Fallback to in-memory logging - deviates from Chronicle Logger's persistence contract.
 Rationale for Decision::
 * Prevents silent data loss, aligns with operational expectations in regulated environments.
 Impact & Consequences::
@@ -44,7 +44,7 @@ Context::
 Decision Statement::
 * `ChronicleLogReader` must remain allocation-neutral during steady-state reads and expose benchmarks that enforce the constraint.
 Alternatives Considered::
-* Accept sporadic allocations – risks latency regressions and contradicts Chronicle low-GC ethos.
+* Accept sporadic allocations - risks latency regressions and contradicts Chronicle low-GC ethos.
 Rationale for Decision::
 * Sustains deterministic behaviour for monitoring tools and aligns with performance requirements.
 Impact & Consequences::

--- a/src/main/docs/project-requirements.adoc
+++ b/src/main/docs/project-requirements.adoc
@@ -44,24 +44,24 @@ benchmark job executes weekly and publishes trend reports; spot checks confirm n
 regressions before releases.
 |===
 
-== Non-Functional Requirements – Performance
+== Non-Functional Requirements - Performance
 
 [cols="1,5,4",options="header"]
 |===
 |ID |Requirement |Benchmark Target
 |CLG-NF-P-001 |Steady-state append of INFO level messages through SLF4J 1.x binding
-shall achieve ≥ 1.2 million events per second on a 3.2 GHz x86-64 host with
+shall achieve >= 1.2 million events per second on a 3.2 GHz x86-64 host with
 Chronicle Queue BINARY_LIGHT. |JMH `Throughput` benchmark in `benchmark` module;
 flagged if throughput drops by > 10 percent relative to baseline.
 |CLG-NF-P-002 |Tail latency (99.9 percentile) for append operations with async
-queue roll shall remain ≤ 750 microseconds under mixed INFO/WARN traffic. |Benchmark
+queue roll shall remain <= 750 microseconds under mixed INFO/WARN traffic. |Benchmark
 module scenario combining timed roll cycle and mixed levels.
-|CLG-NF-P-003 |`ChronicleLogReader` shall consume existing queues at ≥ 500k events
+|CLG-NF-P-003 |`ChronicleLogReader` shall consume existing queues at >= 500k events
 per second while remaining allocation-neutral. |Micro benchmark comparing reader
 performance to baseline sample queues.
 |===
 
-== Non-Functional Requirements – Security and Operability
+== Non-Functional Requirements - Security and Operability
 
 [cols="1,5,4",options="header"]
 |===
@@ -88,7 +88,7 @@ exercise concurrent reloads with leak detectors enabled.
 [cols="1,5",options="header"]
 |===
 |ID |Requirement
-|CLG-TEST-001 |Maintain ≥ 80 percent line coverage for `logger-core` and each
+|CLG-TEST-001 |Maintain >= 80 percent line coverage for `logger-core` and each
 binding package, excluding generated or vendor code.
 Jacoco gate enforced in CI.
 |CLG-TEST-002 |Provide regression fixtures per binding that append structured


### PR DESCRIPTION
## Summary
Documentation is expected to stay within 8-bit (1-255) so characters outside that range are folded to their closest Latin-1/ASCII forms:

| Before | After |
|--------|-------|
| en-dash, non-breaking hyphen, figure dash | `-` |
| em-dash, horizontal bar | `--` |
| ellipsis | `...` |
| zero-width space / joiners / direction marks | *removed* |
| smart single quotes `'` `'` | `'` |
| smart double quotes `"` `"` | `"` |
| `<=`, `>=` | `<=`, `>=` |

Latin-1 characters (micro sign, non-breaking space, etc.) are left alone.

## Test plan
- [ ] Rendered output still reads naturally.
- [ ] No code semantics affected (text-only files).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)