### PR TITLE
docs: fix broken AGENTS.md paths to project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,8 @@ mvn -q verify
 
 ## Project requirements
 
-See the [Decision Log](adoc/decision-log.adoc) for the latest project decisions.
-See the [Project Requirements](adoc/project-requirements.adoc) for details on project requirements.
+See the [Decision Log](src/main/docs/decision-log.adoc) for the latest project decisions.
+See the [Project Requirements](src/main/docs/project-requirements.adoc) for details on project requirements.
 
 ## Elevating the Workflow with Real-Time Documentation
 


### PR DESCRIPTION
Point Decision Log / Project Requirements references at the actual file paths instead of non-existent directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)